### PR TITLE
Non-snapshot dependency

### DIFF
--- a/examples/java/NewRelicExampleJava/pom.xml
+++ b/examples/java/NewRelicExampleJava/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.newrelic.opentracing</groupId>
             <artifactId>java-aws-lambda</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>


### PR DESCRIPTION
Now that the relevant change has merged and been published, we can
use a real version number.