### PR TITLE
Add the accountId to the bucket name

### DIFF
--- a/examples/dotnet/deploy.sh
+++ b/examples/dotnet/deploy.sh
@@ -7,7 +7,7 @@ echo "region set to ${region}"
 
 sam build
 
-bucket="newrelic-example-${region}"
+bucket="newrelic-example-${region}-${accountId}"
 
 aws s3 mb s3://${bucket}
 

--- a/examples/go/deploy.sh
+++ b/examples/go/deploy.sh
@@ -20,7 +20,7 @@ fi
 env GOARCH=amd64 GOOS=linux go build ${build_tags} -ldflags="-s -w" -o ${handler}
 zip go-example.zip "${handler}"
 
-bucket="newrelic-example-${region}"
+bucket="newrelic-example-${region}-${accountId}"
 aws s3 mb s3://${bucket}
 aws s3 cp go-example.zip s3://${bucket}
 aws cloudformation deploy --region ${region} \

--- a/examples/java/deploy.sh
+++ b/examples/java/deploy.sh
@@ -7,7 +7,7 @@ echo "region set to ${region}"
 
 sam build --use-container
 
-bucket="newrelic-example-${region}"
+bucket="newrelic-example-${region}-${accountId}"
 
 aws s3 mb s3://${bucket}
 

--- a/examples/node/deploy.sh
+++ b/examples/node/deploy.sh
@@ -7,7 +7,7 @@ echo "region set to ${region}"
 
 sam build --use-container
 
-bucket="newrelic-example-${region}"
+bucket="newrelic-example-${region}-${accountId}"
 
 aws s3 mb s3://${bucket}
 

--- a/examples/python/deploy.sh
+++ b/examples/python/deploy.sh
@@ -7,7 +7,7 @@ echo "region set to ${region}"
 
 sam build --use-container
 
-bucket="newrelic-example-${region}"
+bucket="newrelic-example-${region}-${accountId}"
 
 aws s3 mb s3://${bucket}
 


### PR DESCRIPTION
The S3 bucket namespace is flat. Adding the account ID makes it
less likely that the user will run into issues with the deploy script.