### PR TITLE
Disable Lambda Extension By Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ to install the managed secret, and then add the permission for the secret to you
 
 Each of the example functions in the `examples` directory has the appropriate license key secret permission. 
 
+The New Relic Lambda Extension is disabled by default. To enable it, after adding or
+updating the Lambda layer, set the `NEW_RELIC_LAMBDA_EXTENSION_ENABLED` environment
+variable to any value.
+
 After deploying your AWS Lambda function with one of the layer ARNs from the
 link above you should begin seeing telemetry data in New Relic.
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,19 +3,19 @@ package config
 import "os"
 
 type Configuration struct {
-	UseCloudWatchIngest bool
-	LicenseKey          *string
-	LicenseKeySecretId  *string
-	TelemetryEndpoint   *string
+	ExtensionEnabled   bool
+	LicenseKey         *string
+	LicenseKeySecretId *string
+	TelemetryEndpoint  *string
 }
 
 func ConfigurationFromEnvironment() Configuration {
-	_, useCW := os.LookupEnv("NEW_RELIC_CLOUDWATCH_INGEST")
+	_, extensionEnabled := os.LookupEnv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED")
 	licenseKey, lkOverride := os.LookupEnv("NEW_RELIC_LICENSE_KEY")
 	licenseKeySecretId, lkSecretOverride := os.LookupEnv("NEW_RELIC_LICENSE_KEY_SECRET")
 	telemetryEndpoint, teOverride := os.LookupEnv("NEW_RELIC_TELEMETRY_ENDPOINT")
 
-	ret := Configuration{UseCloudWatchIngest: useCW}
+	ret := Configuration{ExtensionEnabled: extensionEnabled}
 
 	if lkOverride {
 		ret.LicenseKey = &licenseKey

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,20 +12,27 @@ func TestConfigurationFromEnvironmentZero(t *testing.T) {
 }
 
 func TestConfigurationFromEnvironment(t *testing.T) {
-	os.Setenv("NEW_RELIC_CLOUDWATCH_INGEST", "set")
+	os.Unsetenv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED")
+
+	conf := ConfigurationFromEnvironment()
+
+	assert.Equal(t, conf.ExtensionEnabled, false)
+
+	os.Setenv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED", "set")
 	os.Setenv("NEW_RELIC_LICENSE_KEY", "lk")
 	os.Setenv("NEW_RELIC_LICENSE_KEY_SECRET", "secretId")
 	os.Setenv("NEW_RELIC_TELEMETRY_ENDPOINT", "endpoint")
-	defer func () {
-		os.Unsetenv("NEW_RELIC_CLOUDWATCH_INGEST")
+
+	defer func() {
+		os.Unsetenv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED")
 		os.Unsetenv("NEW_RELIC_LICENSE_KEY")
 		os.Unsetenv("NEW_RELIC_LICENSE_KEY_SECRET")
 		os.Unsetenv("NEW_RELIC_TELEMETRY_ENDPOINT")
 	}()
 
-	conf := ConfigurationFromEnvironment()
+	conf = ConfigurationFromEnvironment()
 
-	assert.Equal(t, true, conf.UseCloudWatchIngest)
+	assert.Equal(t, conf.ExtensionEnabled, true)
 	assert.Equal(t, "lk", *conf.LicenseKey)
 	assert.Nil(t, conf.LicenseKeySecretId)
 	assert.Equal(t, "endpoint", *conf.TelemetryEndpoint)

--- a/examples/dotnet/template.yaml
+++ b/examples/dotnet/template.yaml
@@ -20,6 +20,7 @@ Resources:
       Timeout: 6
       Environment:
         Variables:
+          NEW_RELIC_LAMBDA_EXTENSION_ENABLED: true
           NEW_RELIC_ACCOUNT_ID: !Sub ${NRAccountId}
       Layers:
         # This layer includes the New Relic Lambda Extension, a sidecar process that sends telemetry.

--- a/examples/go/template.yaml
+++ b/examples/go/template.yaml
@@ -22,6 +22,7 @@ Resources:
       Runtime: provided
       Environment:
         Variables:
+          NEW_RELIC_LAMBDA_EXTENSION_ENABLED: true
           NEW_RELIC_ACCOUNT_ID: !Sub ${NRAccountId}
           NEW_RELIC_TRUSTED_ACCOUNT_KEY: !Sub ${NRAccountId}
       Layers:

--- a/examples/java/template.yaml
+++ b/examples/java/template.yaml
@@ -22,6 +22,7 @@ Resources:
       MemorySize: 512
       Environment:
         Variables:
+          NEW_RELIC_LAMBDA_EXTENSION_ENABLED: true
           NEW_RELIC_ACCOUNT_ID: !Sub ${NRAccountId}
       Layers:
         # This layer includes the New Relic Lambda Extension, a sidecar process that sends telemetry,

--- a/examples/node/template.yaml
+++ b/examples/node/template.yaml
@@ -21,6 +21,7 @@ Resources:
       Runtime: nodejs12.x
       Environment:
         Variables:
+          NEW_RELIC_LAMBDA_EXTENSION_ENABLED: true
           # For the instrumentation handler to invoke your real handler, we need this value
           NEW_RELIC_LAMBDA_HANDLER: app.lambdaHandler
           NEW_RELIC_ACCOUNT_ID: !Sub ${NRAccountId}

--- a/examples/python/template.yaml
+++ b/examples/python/template.yaml
@@ -21,6 +21,7 @@ Resources:
       Runtime: python3.8
       Environment:
         Variables:
+          NEW_RELIC_LAMBDA_EXTENSION_ENABLED: true
           # For the instrumentation handler to invoke your real handler, we need this value
           NEW_RELIC_LAMBDA_HANDLER: app.lambda_handler
           NEW_RELIC_ACCOUNT_ID: !Sub ${NRAccountId}

--- a/main.go
+++ b/main.go
@@ -18,15 +18,17 @@ func main() {
 
 	registrationClient := client.New(http.Client{})
 	regReq := api.RegistrationRequest{
-		Events:            []api.LifecycleEvent{api.Invoke, api.Shutdown},
+		Events: []api.LifecycleEvent{api.Invoke, api.Shutdown},
 	}
+
 	invocationClient, registrationResponse, err := registrationClient.Register(regReq)
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	conf := config.ConfigurationFromEnvironment()
 
-	if conf.UseCloudWatchIngest {
+	if conf.ExtensionEnabled == false {
 		log.Println("Extension telemetry processing disabled")
 		noopLoop(invocationClient)
 		return


### PR DESCRIPTION
This changes the behavior of the Lambda Extension. Instead of being
enabled by default, it will instead be disabled by default and need to
be enabled via a `NEW_RELIC_LAMBDA_EXTENSION_ENABLED` enviornment
variable.