### PR TITLE
Support region for deploy.sh.

### DIFF
--- a/examples/dotnet/deploy.sh
+++ b/examples/dotnet/deploy.sh
@@ -9,7 +9,7 @@ sam build
 
 bucket="newrelic-example-${region}-${accountId}"
 
-aws s3 mb s3://${bucket}
+aws s3 mb s3://${bucket} --region ${region}
 
 sam package --region ${region} --s3-bucket=${bucket} --output-template-file packaged.yaml
 aws cloudformation deploy --region ${region} \

--- a/examples/go/deploy.sh
+++ b/examples/go/deploy.sh
@@ -21,7 +21,7 @@ env GOARCH=amd64 GOOS=linux go build ${build_tags} -ldflags="-s -w" -o ${handler
 zip go-example.zip "${handler}"
 
 bucket="newrelic-example-${region}-${accountId}"
-aws s3 mb s3://${bucket}
+aws s3 mb s3://${bucket} --region ${region}
 aws s3 cp go-example.zip s3://${bucket}
 aws cloudformation deploy --region ${region} \
   --template-file template.yaml \

--- a/examples/go/template.yaml
+++ b/examples/go/template.yaml
@@ -13,7 +13,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri:
-        Bucket: !Sub newrelic-example-${AWS::Region}
+        Bucket: !Sub newrelic-example-${AWS::Region}-${NRAccountId}
         Key: go-example.zip
       Description: A simple Lambda, with New Relic telemetry
       FunctionName: newrelic-example-go

--- a/examples/java/deploy.sh
+++ b/examples/java/deploy.sh
@@ -9,7 +9,7 @@ sam build --use-container
 
 bucket="newrelic-example-${region}-${accountId}"
 
-aws s3 mb s3://${bucket}
+aws s3 mb s3://${bucket} --region ${region}
 
 sam package --region ${region} --s3-bucket=${bucket} --output-template-file packaged.yaml
 aws cloudformation deploy --region ${region} \

--- a/examples/node/deploy.sh
+++ b/examples/node/deploy.sh
@@ -9,7 +9,7 @@ sam build --use-container
 
 bucket="newrelic-example-${region}-${accountId}"
 
-aws s3 mb s3://${bucket}
+aws s3 mb s3://${bucket} --region ${region}
 
 sam package --region ${region} --s3-bucket=${bucket} --output-template-file packaged.yaml
 aws cloudformation deploy --region ${region} \

--- a/examples/python/deploy.sh
+++ b/examples/python/deploy.sh
@@ -9,7 +9,7 @@ sam build --use-container
 
 bucket="newrelic-example-${region}-${accountId}"
 
-aws s3 mb s3://${bucket}
+aws s3 mb s3://${bucket} --region ${region}
 
 sam package --region ${region} --s3-bucket=${bucket} --output-template-file packaged.yaml
 aws cloudformation deploy --region ${region} \


### PR DESCRIPTION
When the region is specified other than the default one, the current deploy.sh failed when creating a bucket or cloudformation for the go template.