### PR TITLE
Workaround for missing function name

### DIFF
--- a/lambda/extension/client/client.go
+++ b/lambda/extension/client/client.go
@@ -87,6 +87,7 @@ func (rc *RegistrationClient) Register(registrationRequest api.RegistrationReque
 	if err != nil {
 		return nil, nil, err
 	}
+	util.Debugf("Registration response: %s", bodyBytes)
 
 	var registrationResponse api.RegistrationResponse
 	err = json.Unmarshal(bodyBytes, &registrationResponse)

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -57,6 +57,16 @@ func (c *Client) SendTelemetry(invokedFunctionARN string, telemetry [][]byte) er
 		logEvents = append(logEvents, logEvent)
 	}
 
+	if len(c.functionName) == 0  {
+		nameStart := strings.Index(invokedFunctionARN, ":function:") + len(":function:")
+		nameLen := strings.Index(invokedFunctionARN[nameStart:], ":")
+		if nameLen < 0 {
+			nameLen = len(invokedFunctionARN) - nameStart
+		}
+		c.functionName = invokedFunctionARN[nameStart:nameStart+nameLen]
+		util.Debugf("Recovered missing function name: %s", c.functionName)
+	}
+
 	compressedPayloads, err := CompressedPayloadsForLogEvents(logEvents, c.functionName, invokedFunctionARN)
 	if err != nil {
 		return err

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -57,13 +57,13 @@ func (c *Client) SendTelemetry(invokedFunctionARN string, telemetry [][]byte) er
 		logEvents = append(logEvents, logEvent)
 	}
 
-	if len(c.functionName) == 0  {
+	if len(c.functionName) == 0 {
 		nameStart := strings.Index(invokedFunctionARN, ":function:") + len(":function:")
 		nameLen := strings.Index(invokedFunctionARN[nameStart:], ":")
 		if nameLen < 0 {
 			nameLen = len(invokedFunctionARN) - nameStart
 		}
-		c.functionName = invokedFunctionARN[nameStart:nameStart+nameLen]
+		c.functionName = invokedFunctionARN[nameStart : nameStart+nameLen]
 		util.Debugf("Recovered missing function name: %s", c.functionName)
 	}
 

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -42,7 +42,7 @@ func TestClientSend(t *testing.T) {
 	client := NewWithHTTPClient(srv.Client(), "", "a mock license key", &srv.URL)
 
 	bytes := []byte("foobar")
-	err := client.SendTelemetry("fakeArn", [][]byte{bytes})
+	err := client.SendTelemetry("arn:aws:lambda:us-east-1:1234:function:newrelic-example-go", [][]byte{bytes})
 
 	assert.NoError(t, err)
 }

--- a/telemetry/request.go
+++ b/telemetry/request.go
@@ -65,7 +65,7 @@ func CompressedPayloadsForLogEvents(logsEvents []LogsEvent, functionName string,
 		FunctionName:       functionName,
 		InvokedFunctionARN: invokedFunctionARN,
 		LogGroupName:       logGroupName,
-		LogStreamName:      "newrelic-lambda-extension:1.0.1",
+		LogStreamName:      "newrelic-lambda-extension:1.0.2",
 	}
 	data := RequestData{Context: context, Entry: string(entry)}
 


### PR DESCRIPTION
The registration response is documented to include the
function name, and we rely on that. But apparently, it's blank
right now.