### PR TITLE
Kwest/lambda 990

### DIFF
--- a/checks/handlerCheck.go
+++ b/checks/handlerCheck.go
@@ -10,9 +10,9 @@ import (
 	"github.com/newrelic/newrelic-lambda-extension/lambda/extension/api"
 )
 
-type handlerRuntime func(HandlerConfigs) error
+type handlerRuntime func(handlerConfigs) error
 
-type HandlerConfigs struct {
+type handlerConfigs struct {
 	handlerName string
 	conf        *config.Configuration
 }
@@ -29,12 +29,10 @@ var handlerPath = "/var/task"
 
 func checkHandler(conf *config.Configuration, reg *api.RegistrationResponse) error {
 	functionHandler := reg.Handler
-	fmt.Println(functionHandler)
-	fmt.Println("hello from check handler")
 	for k, v := range handlerCheck {
 		err := checkRuntime(k)
 		if err == nil {
-			h := HandlerConfigs{
+			h := handlerConfigs{
 				handlerName: functionHandler,
 				conf:        conf,
 			}
@@ -51,47 +49,47 @@ func checkHandler(conf *config.Configuration, reg *api.RegistrationResponse) err
 }
 
 func checkRuntime(runtime string) error {
-	path := fmt.Sprintf("/var/lang/bin/%s", runtime)
-	return pathExists(path)
+	p := fmt.Sprintf("/var/lang/bin/%s", runtime)
+	return pathExists(p)
 }
 
 // Handler format for dotnet functions: Assembly::Namespace.ClassName::Method
 // from the file names alone all that we can validate is the Assembly dll
-func dotnet(h HandlerConfigs) error {
-	path := pathFormatter(h.handlerName, "dll")
-	return pathExists(path)
+func dotnet(h handlerConfigs) error {
+	p := pathFormatter(h.handlerName, "dll")
+	return pathExists(p)
 }
 
 // Handler format for java functions: package.Class::method
 // we can validate that the package + class path exist
 // and want to validate that the method value is set to interface method handleRequest
-func java(h HandlerConfigs) error {
+func java(h handlerConfigs) error {
 	if !strings.HasSuffix(h.handlerName, "handleRequest") {
 		return fmt.Errorf("Function handler missing required 'handleRequest' method")
 	}
-	path := pathFormatter(h.handlerName, "class")
-	return pathExists(path)
+	p := pathFormatter(h.handlerName, "class")
+	return pathExists(p)
 }
 
 // Hander format for node functions: file.function
 // we can validate that the handler has been set to newrelic-lambda-wrapper.handler"
 // and that the file name provided in the env var NEW_RELIC_LAMBDA_HANDLER exists
-func node(h HandlerConfigs) error {
+func node(h handlerConfigs) error {
 	functionHandler := checkNrHandler(h, "-")
-	path := pathFormatter(functionHandler, "js")
-	return pathExists(path)
+	p := pathFormatter(functionHandler, "js")
+	return pathExists(p)
 }
 
 // Hander format for python functions: file.function
 // we can validate that the handler has been set to newrelic_lambda_wrapper.handler
 // and that the file name provided in the env var NEW_RELIC_LAMBDA_HANDLER exists
-func python(h HandlerConfigs) error {
+func python(h handlerConfigs) error {
 	functionHandler := checkNrHandler(h, "_")
-	path := pathFormatter(functionHandler, "py")
-	return pathExists(path)
+	p := pathFormatter(functionHandler, "py")
+	return pathExists(p)
 }
 
-func checkNrHandler(h HandlerConfigs, dividingChar string) string {
+func checkNrHandler(h handlerConfigs, dividingChar string) string {
 	wrapper := strings.ReplaceAll(NEW_RELIC_LAMBDA_WRAPPER, "|", dividingChar)
 	if h.handlerName != wrapper {
 		return h.handlerName
@@ -109,14 +107,12 @@ func pathFormatter(functionHandler string, fileType string) string {
 		functionHandler = strings.Join(s[:len(s)-1], "/")
 	}
 
-	path := fmt.Sprintf("%s/%s.%s", handlerPath, functionHandler, fileType)
-	fmt.Println("my path")
-	fmt.Println(path)
-	return path
+	p := fmt.Sprintf("%s/%s.%s", handlerPath, functionHandler, fileType)
+	return p
 }
 
-func pathExists(path string) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+func pathExists(p string) error {
+	if _, err := os.Stat(p); os.IsNotExist(err) {
 		return err
 	}
 	return nil

--- a/checks/handlerCheck.go
+++ b/checks/handlerCheck.go
@@ -1,0 +1,123 @@
+package checks
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/newrelic/newrelic-lambda-extension/config"
+	"github.com/newrelic/newrelic-lambda-extension/lambda/extension/api"
+)
+
+type handlerRuntime func(HandlerConfigs) error
+
+type HandlerConfigs struct {
+	handlerName string
+	conf        *config.Configuration
+}
+
+var handlerCheck = map[string]handlerRuntime{
+	"dotnet": dotnet,
+	"java":   java,
+	"node":   node,
+	"python": python,
+}
+
+var NEW_RELIC_LAMBDA_WRAPPER = "newrelic|lambda|wrapper.handler"
+var handlerPath = "/var/task"
+
+func checkHandler(conf *config.Configuration, reg *api.RegistrationResponse) error {
+	functionHandler := reg.Handler
+	fmt.Println(functionHandler)
+	fmt.Println("hello from check handler")
+	for k, v := range handlerCheck {
+		err := checkRuntime(k)
+		if err == nil {
+			h := HandlerConfigs{
+				handlerName: functionHandler,
+				conf:        conf,
+			}
+			err = v(h)
+			if err != nil {
+				return fmt.Errorf("Lambda handler is set incorrectly: %s", err)
+			}
+			break
+		}
+	}
+	// If we make it here that means the runtime is
+	// custom and we don't want to throw an error
+	return nil
+}
+
+func checkRuntime(runtime string) error {
+	path := fmt.Sprintf("/var/lang/bin/%s", runtime)
+	return pathExists(path)
+}
+
+// Handler format for dotnet functions: Assembly::Namespace.ClassName::Method
+// from the file names alone all that we can validate is the Assembly dll
+func dotnet(h HandlerConfigs) error {
+	path := pathFormatter(h.handlerName, "dll")
+	return pathExists(path)
+}
+
+// Handler format for java functions: package.Class::method
+// we can validate that the package + class path exist
+// and want to validate that the method value is set to interface method handleRequest
+func java(h HandlerConfigs) error {
+	if !strings.HasSuffix(h.handlerName, "handleRequest") {
+		return fmt.Errorf("Function handler missing required 'handleRequest' method")
+	}
+	path := pathFormatter(h.handlerName, "class")
+	return pathExists(path)
+}
+
+// Hander format for node functions: file.function
+// we can validate that the handler has been set to newrelic-lambda-wrapper.handler"
+// and that the file name provided in the env var NEW_RELIC_LAMBDA_HANDLER exists
+func node(h HandlerConfigs) error {
+	functionHandler := checkNrHandler(h, "-")
+	path := pathFormatter(functionHandler, "js")
+	return pathExists(path)
+}
+
+// Hander format for python functions: file.function
+// we can validate that the handler has been set to newrelic_lambda_wrapper.handler
+// and that the file name provided in the env var NEW_RELIC_LAMBDA_HANDLER exists
+func python(h HandlerConfigs) error {
+	functionHandler := checkNrHandler(h, "_")
+	path := pathFormatter(functionHandler, "py")
+	return pathExists(path)
+}
+
+func checkNrHandler(h HandlerConfigs, dividingChar string) string {
+	wrapper := strings.ReplaceAll(NEW_RELIC_LAMBDA_WRAPPER, "|", dividingChar)
+	if h.handlerName != wrapper {
+		return h.handlerName
+	}
+	return *h.conf.NRHandler
+}
+
+func pathFormatter(functionHandler string, fileType string) string {
+	re := regexp.MustCompile("[::.]+")
+	s := re.Split(functionHandler, -1)
+
+	if fileType == "dll" {
+		functionHandler = s[0]
+	} else {
+		functionHandler = strings.Join(s[:len(s)-1], "/")
+	}
+
+	path := fmt.Sprintf("%s/%s.%s", handlerPath, functionHandler, fileType)
+	fmt.Println("my path")
+	fmt.Println(path)
+	return path
+}
+
+func pathExists(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/checks/handlerCheck.go
+++ b/checks/handlerCheck.go
@@ -3,7 +3,6 @@ package checks
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/newrelic/newrelic-lambda-extension/config"
@@ -18,29 +17,23 @@ type handlerConfigs struct {
 }
 
 var handlerCheck = map[string]handlerRuntime{
-	"dotnet": dotnet,
-	"java":   java,
 	"node":   node,
 	"python": python,
 }
 
-var NEW_RELIC_LAMBDA_WRAPPER = "newrelic|lambda|wrapper.handler"
-var handlerPath = "/var/task"
+var pathExists = func(p string) error {
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
 
-func checkHandler(conf *config.Configuration, reg *api.RegistrationResponse) error {
-	functionHandler := reg.Handler
+var checkAndReturnRuntime = func() handlerRuntime {
 	for k, v := range handlerCheck {
-		err := checkRuntime(k)
+		p := fmt.Sprintf("/var/lang/bin/%s", k)
+		err := pathExists(p)
 		if err == nil {
-			h := handlerConfigs{
-				handlerName: functionHandler,
-				conf:        conf,
-			}
-			err = v(h)
-			if err != nil {
-				return fmt.Errorf("Lambda handler is set incorrectly: %s", err)
-			}
-			break
+			return v
 		}
 	}
 	// If we make it here that means the runtime is
@@ -48,72 +41,56 @@ func checkHandler(conf *config.Configuration, reg *api.RegistrationResponse) err
 	return nil
 }
 
-func checkRuntime(runtime string) error {
-	p := fmt.Sprintf("/var/lang/bin/%s", runtime)
-	return pathExists(p)
-}
+var handlerPath = "/var/task"
 
-// Handler format for dotnet functions: Assembly::Namespace.ClassName::Method
-// from the file names alone all that we can validate is the Assembly dll
-func dotnet(h handlerConfigs) error {
-	p := pathFormatter(h.handlerName, "dll")
-	return pathExists(p)
-}
-
-// Handler format for java functions: package.Class::method
-// we can validate that the package + class path exist
-// and want to validate that the method value is set to interface method handleRequest
-func java(h handlerConfigs) error {
-	if !strings.HasSuffix(h.handlerName, "handleRequest") {
-		return fmt.Errorf("Function handler missing required 'handleRequest' method")
+func checkHandler(conf *config.Configuration, reg *api.RegistrationResponse) error {
+	r := checkAndReturnRuntime()
+	if r != nil {
+		h := handlerConfigs{
+			handlerName: reg.Handler,
+			conf:        conf,
+		}
+		err := r(h)
+		if err != nil {
+			return fmt.Errorf("Lambda handler is set incorrectly: %s", err)
+		}
 	}
-	p := pathFormatter(h.handlerName, "class")
-	return pathExists(p)
+	return nil
 }
 
-// Hander format for node functions: file.function
+// Handler format for node functions: file.function
 // we can validate that the handler has been set to newrelic-lambda-wrapper.handler"
 // and that the file name provided in the env var NEW_RELIC_LAMBDA_HANDLER exists
 func node(h handlerConfigs) error {
-	functionHandler := checkNrHandler(h, "-")
-	p := pathFormatter(functionHandler, "js")
+	functionHandler := getTrueHandler(h, "newrelic-lambda-wrapper.handler")
+	p := removePathMethodName(functionHandler)
+	p = pathFormatter(p, "js")
 	return pathExists(p)
 }
 
-// Hander format for python functions: file.function
+// Handler format for python functions: file.function
 // we can validate that the handler has been set to newrelic_lambda_wrapper.handler
 // and that the file name provided in the env var NEW_RELIC_LAMBDA_HANDLER exists
 func python(h handlerConfigs) error {
-	functionHandler := checkNrHandler(h, "_")
-	p := pathFormatter(functionHandler, "py")
+	functionHandler := getTrueHandler(h, "newrelic_lambda_wrapper.handler")
+	p := removePathMethodName(functionHandler)
+	p = pathFormatter(functionHandler, "py")
 	return pathExists(p)
 }
 
-func checkNrHandler(h handlerConfigs, dividingChar string) string {
-	wrapper := strings.ReplaceAll(NEW_RELIC_LAMBDA_WRAPPER, "|", dividingChar)
-	if h.handlerName != wrapper {
+func getTrueHandler(h handlerConfigs, w string) string {
+	if h.handlerName != w {
 		return h.handlerName
 	}
 	return *h.conf.NRHandler
 }
 
 func pathFormatter(functionHandler string, fileType string) string {
-	re := regexp.MustCompile("[::.]+")
-	s := re.Split(functionHandler, -1)
-
-	if fileType == "dll" {
-		functionHandler = s[0]
-	} else {
-		functionHandler = strings.Join(s[:len(s)-1], "/")
-	}
-
 	p := fmt.Sprintf("%s/%s.%s", handlerPath, functionHandler, fileType)
 	return p
 }
 
-func pathExists(p string) error {
-	if _, err := os.Stat(p); os.IsNotExist(err) {
-		return err
-	}
-	return nil
+func removePathMethodName(p string) string {
+	s := strings.Split(p, ".")
+	return strings.Join(s[:len(s)-1], "/")
 }

--- a/checks/handlerCheck_test.go
+++ b/checks/handlerCheck_test.go
@@ -1,0 +1,66 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/newrelic/newrelic-lambda-extension/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathFormatterJava(t *testing.T) {
+	testHandler := "com.newrelic.lambda.example.App::handleRequest"
+	e := "/var/task/com/newrelic/lambda/example/App.java"
+	r := pathFormatter(testHandler, "java")
+	assert.Equal(t, e, r)
+}
+
+func TestJavaMethodError(t *testing.T) {
+	h := handlerConfigs{
+		handlerName: "com.newrelic.lambda.example.App::foobar",
+		conf:        &config.Configuration{},
+	}
+	err := java(h)
+	assert.Error(t, err)
+}
+
+func TestPathFormatterDotnet(t *testing.T) {
+	testHandler := "NewRelicExampleDotnet::NewRelicExampleDotnet.Function::FunctionHandler"
+	e := "/var/task/NewRelicExampleDotnet.dll"
+	r := pathFormatter(testHandler, "dll")
+	assert.Equal(t, e, r)
+}
+
+func TestPathFormatterPython(t *testing.T) {
+	testHandler := "path/to/app.lambda_handler"
+	e := "/var/task/path/to/app.py"
+	r := pathFormatter(testHandler, "py")
+	assert.Equal(t, e, r)
+}
+
+func TestPathFormatterNode(t *testing.T) {
+	testHandler := "path/to/app.lambda_handler"
+	e := "/var/task/path/to/app.js"
+	r := pathFormatter(testHandler, "js")
+	assert.Equal(t, e, r)
+}
+
+func TestCheckNrHandlerTrue(t *testing.T) {
+	e := "path/to/app.lambda_handler"
+	c := config.Configuration{}
+	c.NRHandler = &e
+	h := handlerConfigs{
+		handlerName: "newrelic-lambda-wrapper.handler",
+		conf:        &c,
+	}
+	r := checkNrHandler(h, "-")
+	assert.Equal(t, e, r)
+}
+
+func TestCheckNrHandlerFalse(t *testing.T) {
+	h := handlerConfigs{
+		handlerName: "hello-world/app.haldoer",
+		conf:        &config.Configuration{},
+	}
+	r := checkNrHandler(h, "-")
+	assert.Equal(t, h.handlerName, r)
+}

--- a/checks/handlerCheck_test.go
+++ b/checks/handlerCheck_test.go
@@ -1,50 +1,83 @@
 package checks
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/newrelic/newrelic-lambda-extension/config"
+	"github.com/newrelic/newrelic-lambda-extension/lambda/extension/api"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPathFormatterJava(t *testing.T) {
-	testHandler := "com.newrelic.lambda.example.App::handleRequest"
-	e := "/var/task/com/newrelic/lambda/example/App.java"
-	r := pathFormatter(testHandler, "java")
-	assert.Equal(t, e, r)
-}
+var testHandler = "path/to/app.handler"
 
-func TestJavaMethodError(t *testing.T) {
-	h := handlerConfigs{
-		handlerName: "com.newrelic.lambda.example.App::foobar",
-		conf:        &config.Configuration{},
+func TestHandlerCheckSuccess(t *testing.T) {
+	pathExists = func(p string) error {
+		return nil
 	}
-	err := java(h)
-	assert.Error(t, err)
+	checkAndReturnRuntime = func() handlerRuntime {
+		return node
+	}
+	conf := config.Configuration{}
+	resp := api.RegistrationResponse{}
+	err := checkHandler(&conf, &resp)
+
+	assert.Nil(t, err)
 }
 
-func TestPathFormatterDotnet(t *testing.T) {
-	testHandler := "NewRelicExampleDotnet::NewRelicExampleDotnet.Function::FunctionHandler"
-	e := "/var/task/NewRelicExampleDotnet.dll"
-	r := pathFormatter(testHandler, "dll")
-	assert.Equal(t, e, r)
+func TestHandlerCheckError(t *testing.T) {
+	pathExists = func(p string) error {
+		return errors.New("Error!")
+	}
+	checkAndReturnRuntime = func() handlerRuntime {
+		return node
+	}
+	conf := config.Configuration{}
+	resp := api.RegistrationResponse{}
+	err := checkHandler(&conf, &resp)
+
+	assert.EqualError(t, err, "Lambda handler is set incorrectly: Error!")
 }
 
-func TestPathFormatterPython(t *testing.T) {
-	testHandler := "path/to/app.lambda_handler"
-	e := "/var/task/path/to/app.py"
-	r := pathFormatter(testHandler, "py")
-	assert.Equal(t, e, r)
+func TestPathPython(t *testing.T) {
+	c := config.Configuration{NRHandler: &testHandler}
+	h := handlerConfigs{
+		handlerName: "newrelic_lambda_wrapper.handler",
+		conf:        &c,
+	}
+	t1 := getTrueHandler(h, "newrelic_lambda_wrapper.handler")
+	t2 := removePathMethodName(t1)
+	t3 := pathFormatter(t2, "py")
+
+	e1 := "path/to/app.handler"
+	e2 := "path/to/app"
+	e3 := "/var/task/path/to/app.py"
+
+	assert.Equal(t, e1, e1)
+	assert.Equal(t, e2, t2)
+	assert.Equal(t, e3, t3)
 }
 
-func TestPathFormatterNode(t *testing.T) {
-	testHandler := "path/to/app.lambda_handler"
-	e := "/var/task/path/to/app.js"
-	r := pathFormatter(testHandler, "js")
-	assert.Equal(t, e, r)
+func TestPathNode(t *testing.T) {
+	c := config.Configuration{NRHandler: &testHandler}
+	h := handlerConfigs{
+		handlerName: "newrelic-lambda-wrapper.handler",
+		conf:        &c,
+	}
+	t1 := getTrueHandler(h, "newrelic-lambda-wrapper.handler")
+	t2 := removePathMethodName(t1)
+	t3 := pathFormatter(t2, "js")
+
+	e1 := "path/to/app.handler"
+	e2 := "path/to/app"
+	e3 := "/var/task/path/to/app.js"
+
+	assert.Equal(t, e1, e1)
+	assert.Equal(t, e2, t2)
+	assert.Equal(t, e3, t3)
 }
 
-func TestCheckNrHandlerTrue(t *testing.T) {
+func TestGetTrueHandlerWith(t *testing.T) {
 	e := "path/to/app.lambda_handler"
 	c := config.Configuration{}
 	c.NRHandler = &e
@@ -52,15 +85,15 @@ func TestCheckNrHandlerTrue(t *testing.T) {
 		handlerName: "newrelic-lambda-wrapper.handler",
 		conf:        &c,
 	}
-	r := checkNrHandler(h, "-")
+	r := getTrueHandler(h, "newrelic-lambda-wrapper.handler")
 	assert.Equal(t, e, r)
 }
 
-func TestCheckNrHandlerFalse(t *testing.T) {
+func TestGetTrueHandlerWithout(t *testing.T) {
 	h := handlerConfigs{
-		handlerName: "hello-world/app.haldoer",
+		handlerName: testHandler,
 		conf:        &config.Configuration{},
 	}
-	r := checkNrHandler(h, "-")
+	r := getTrueHandler(h, "newrelic_lambda_wrapper.handler")
 	assert.Equal(t, h.handlerName, r)
 }

--- a/checks/startupCheck.go
+++ b/checks/startupCheck.go
@@ -2,8 +2,6 @@ package checks
 
 import (
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/newrelic/newrelic-lambda-extension/config"
@@ -13,31 +11,15 @@ import (
 )
 
 type checkFn func(*config.Configuration, *api.RegistrationResponse) error
-type checkRuntime func(handlerConfigs) error
-
-type handlerConfigs struct {
-	handlerName string
-	conf        *config.Configuration
-}
 
 type LogSender interface {
 	SendFunctionLogs(lines []logserver.LogLine) error
 }
 
-// TODO move this
-var NEW_RELIC_LAMBDA_WRAPPER = "newrelic_lambda_wrapper.handler"
-
 /// Register checks here
 var checks = []checkFn{
 	exampleCheckFunction,
 	checkHandler,
-}
-
-var runtimeChecks = map[string]checkRuntime{
-	"dotnet": dotnet,
-	"java":   java,
-	"node":   node,
-	"python": python,
 }
 
 func RunChecks(conf *config.Configuration, reg *api.RegistrationResponse, logSender LogSender) {
@@ -66,84 +48,4 @@ func runCheck(conf *config.Configuration, reg *api.RegistrationResponse, logSend
 
 func exampleCheckFunction(*config.Configuration, *api.RegistrationResponse) error {
 	return nil
-}
-
-// TODO:
-// validate that java handler ends with interface method handleRequest
-// check on custom runtimes
-// tests
-func checkHandler(conf *config.Configuration, reg *api.RegistrationResponse) error {
-	functionHandler := reg.Handler
-
-	for k, v := range runtimeChecks {
-
-		path := fmt.Sprintf("/var/lang/bin/%s", k)
-
-		_, err := os.Stat(path)
-
-		if err == nil {
-			h := handlerConfigs{
-				handlerName: functionHandler,
-				conf:        conf,
-			}
-			err = v(h)
-			if err != nil {
-				return fmt.Errorf("Lambda handler is set incorrectly: %s", err)
-			}
-			break
-		}
-	}
-	return nil
-}
-
-// Handler format for dotnet functions: Assembly::Namespace.ClassName::Method
-// from the file names alone all that we can validate is the Assembly dll
-func dotnet(h handlerConfigs) error {
-	s := strings.Split(h.handlerName, "::")
-	_, err := os.Stat("/var/task/" + s[0] + ".dll")
-	return err
-}
-
-// Handler format for java functions: package.Class::method
-// we can validate that the package + class path exist
-// and want to validate that the method value is set to ::handleRequest
-func java(h handlerConfigs) error {
-	functionHandler := strings.ReplaceAll(h.handlerName, ".", "/")
-	s := strings.Split(functionHandler, "::")
-	_, err := os.Stat("/var/task/" + s[0] + ".class")
-	return err
-}
-
-// Hander format for node functions: file.function
-// we can validate that the handler has been set to newrelic_lambda_wrapper.handler
-// and that the file name provided in the env var NEW_RELIC_LAMBDA_HANDLER exists
-func node(h handlerConfigs) error {
-	functionHandler, err := checkNrHandler(h)
-	if err != nil {
-		return err
-	}
-	s := strings.Split(functionHandler, ".")
-	_, err = os.Stat("/var/task/" + strings.Join(s[:len(s)-1], "/") + ".js")
-	return err
-}
-
-// Hander format for python functions: file.function
-// we can validate that the handler has been set to newrelic_lambda_wrapper.handler
-// and that the file name provided in the env var NEW_RELIC_LAMBDA_HANDLER exists
-func python(h handlerConfigs) error {
-	functionHandler, err := checkNrHandler(h)
-	if err != nil {
-		return err
-	}
-	s := strings.Split(functionHandler, ".")
-	_, err = os.Stat("/var/task/" + strings.Join(s[:len(s)-1], "/") + ".py")
-	return err
-}
-
-func checkNrHandler(h handlerConfigs) (string, error) {
-	if h.handlerName != NEW_RELIC_LAMBDA_WRAPPER {
-		return "", fmt.Errorf("handler value invalid. Must be set as: %s", NEW_RELIC_LAMBDA_WRAPPER)
-	}
-	functionHandler := *h.conf.NRHandler
-	return functionHandler, nil
 }

--- a/checks/startupCheck.go
+++ b/checks/startupCheck.go
@@ -2,22 +2,43 @@ package checks
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/newrelic/newrelic-lambda-extension/config"
 	"github.com/newrelic/newrelic-lambda-extension/lambda/extension/api"
 	"github.com/newrelic/newrelic-lambda-extension/lambda/logserver"
 	"github.com/newrelic/newrelic-lambda-extension/util"
-	"time"
 )
 
 type checkFn func(*config.Configuration, *api.RegistrationResponse) error
 
-type LogSender interface {
-	SendFunctionLogs(lines []logserver.LogLine) error;
+type checkRuntime func(handlerConfigs) error
+
+type handlerConfigs struct {
+	handlerName string
+	conf        *config.Configuration
 }
 
+type LogSender interface {
+	SendFunctionLogs(lines []logserver.LogLine) error
+}
+
+// TODO move this
+var NEW_RELIC_LAMBDA_WRAPPER = "newrelic_lambda_wrapper.handler"
+
 /// Register checks here
-var checks = []checkFn {
+var checks = []checkFn{
 	exampleCheckFunction,
+	checkHandler,
+}
+
+var runtimeChecks = map[string]checkRuntime{
+	"dotnet": dotnet,
+	"java":   java,
+	"node":   node,
+	"python": python,
 }
 
 func RunChecks(conf *config.Configuration, reg *api.RegistrationResponse, logSender LogSender) {
@@ -46,4 +67,82 @@ func runCheck(conf *config.Configuration, reg *api.RegistrationResponse, logSend
 
 func exampleCheckFunction(*config.Configuration, *api.RegistrationResponse) error {
 	return nil
+}
+
+// TODO:
+// validate that java handler ends with ::handleRequest
+// check on custom runtimes
+// error messaging
+// tests
+func checkHandler(conf *config.Configuration, reg *api.RegistrationResponse) error {
+	functionHandler := reg.Handler
+
+	for k, v := range runtimeChecks {
+
+		path := fmt.Sprintf("/var/lang/bin/%s", k)
+
+		_, err := os.Stat(path)
+
+		if err == nil {
+			h := handlerConfigs{
+				handlerName: functionHandler,
+				conf:        conf,
+			}
+			err = v(h)
+			break
+		}
+	}
+	return nil
+}
+
+// Handler format for dotnet functions: Assembly::Namespace.ClassName::Method
+// from the file names alone all that we can validate is the Assembly dll
+func dotnet(h handlerConfigs) error {
+	s := strings.Split(h.handlerName, "::")
+	_, err := os.Stat("/var/task/" + s[0] + ".dll")
+	return err
+}
+
+// Handler format for java functions: package.Class::method
+// we can validate that the package + class path exist
+// and want to validate that the method value is set to ::handleRequest
+func java(h handlerConfigs) error {
+	functionHandler := strings.ReplaceAll(h.handlerName, ".", "/")
+	s := strings.Split(functionHandler, "::")
+	_, err := os.Stat("/var/task/" + s[0] + ".class")
+	return err
+}
+
+// Hander format for node functions: file.function
+// we can validate that the handler has been set to newrelic_lambda_wrapper.handler
+// and that the file name provided in the env var NEW_RELIC_LAMBDA_HANDLER exists
+func node(h handlerConfigs) error {
+	functionHandler, err := checkNrHandler(h)
+	if err != nil {
+		return err
+	}
+	s := strings.Split(functionHandler, ".")
+	_, err = os.Stat("/var/task/" + strings.Join(s[:len(s)-1], "/") + ".js")
+	return err
+}
+
+// Hander format for python functions: file.function
+// we can validate that the handler has been set to newrelic_lambda_wrapper.handler
+// and that the file name provided in the env var NEW_RELIC_LAMBDA_HANDLER exists
+func python(h handlerConfigs) error {
+	functionHandler, err := checkNrHandler(h)
+	if err != nil {
+		return err
+	}
+	s := strings.Split(functionHandler, ".")
+	_, err = os.Stat("/var/task/" + strings.Join(s[:len(s)-1], "/") + ".py")
+	return err
+}
+
+func checkNrHandler(h handlerConfigs) (string, error) {
+	if h.handlerName != NEW_RELIC_LAMBDA_WRAPPER {
+		return "", fmt.Errorf("handler value invalid. Must be set as: %s", NEW_RELIC_LAMBDA_WRAPPER)
+	}
+	functionHandler := *h.conf.NRHandler
+	return functionHandler, nil
 }

--- a/checks/startupCheck.go
+++ b/checks/startupCheck.go
@@ -13,7 +13,6 @@ import (
 )
 
 type checkFn func(*config.Configuration, *api.RegistrationResponse) error
-
 type checkRuntime func(handlerConfigs) error
 
 type handlerConfigs struct {
@@ -70,9 +69,8 @@ func exampleCheckFunction(*config.Configuration, *api.RegistrationResponse) erro
 }
 
 // TODO:
-// validate that java handler ends with ::handleRequest
+// validate that java handler ends with interface method handleRequest
 // check on custom runtimes
-// error messaging
 // tests
 func checkHandler(conf *config.Configuration, reg *api.RegistrationResponse) error {
 	functionHandler := reg.Handler
@@ -89,6 +87,9 @@ func checkHandler(conf *config.Configuration, reg *api.RegistrationResponse) err
 				conf:        conf,
 			}
 			err = v(h)
+			if err != nil {
+				return fmt.Errorf("Lambda handler is set incorrectly: %s", err)
+			}
 			break
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,8 @@ const (
 	DebugLogLevel     = "DEBUG"
 )
 
+var EmptyNRWrapper = "Undefined"
+
 type Configuration struct {
 	ExtensionEnabled   bool
 	LicenseKey         *string
@@ -52,6 +54,8 @@ func ConfigurationFromEnvironment() Configuration {
 
 	if nrOverride {
 		ret.NRHandler = &nrHandler
+	} else {
+		ret.NRHandler = &EmptyNRWrapper
 	}
 
 	if teOverride {

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Configuration struct {
 	ExtensionEnabled   bool
 	LicenseKey         *string
 	LicenseKeySecretId *string
+	NRHandler          *string
 	TelemetryEndpoint  *string
 	LogEndpoint        *string
 	RipeMillis         uint32
@@ -29,6 +30,7 @@ func ConfigurationFromEnvironment() Configuration {
 	enabledStr, extensionEnabledOverride := os.LookupEnv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED")
 	licenseKey, lkOverride := os.LookupEnv("NEW_RELIC_LICENSE_KEY")
 	licenseKeySecretId, lkSecretOverride := os.LookupEnv("NEW_RELIC_LICENSE_KEY_SECRET")
+	nrHandler, nrOverride := os.LookupEnv("NEW_RELIC_LAMBDA_HANDLER")
 	telemetryEndpoint, teOverride := os.LookupEnv("NEW_RELIC_TELEMETRY_ENDPOINT")
 	logEndpoint, leOverride := os.LookupEnv("NEW_RELIC_LOG_ENDPOINT")
 	ripeMillisStr, ripeMillisOverride := os.LookupEnv("NEW_RELIC_HARVEST_RIPE_MILLIS")
@@ -46,6 +48,10 @@ func ConfigurationFromEnvironment() Configuration {
 		ret.LicenseKey = &licenseKey
 	} else if lkSecretOverride {
 		ret.LicenseKeySecretId = &licenseKeySecretId
+	}
+
+	if nrOverride {
+		ret.NRHandler = &nrHandler
 	}
 
 	if teOverride {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigurationFromEnvironmentZero(t *testing.T) {
@@ -13,6 +14,7 @@ func TestConfigurationFromEnvironmentZero(t *testing.T) {
 		RipeMillis:       DefaultRipeMillis,
 		RotMillis:        DefaultRotMillis,
 		LogLevel:         DefaultLogLevel,
+		NRHandler:        &EmptyNRWrapper,
 	}
 	assert.Equal(t, expected, conf)
 }


### PR DESCRIPTION
- Identifying runtime from file system 
- Validating handler values for Node and Python runtimes

https://newrelic.atlassian.net/browse/LAMBDA-990
https://newrelic.atlassian.net/browse/LAMBDA-989

Note: This check does not include a check java, dotnet or custom runtimes. 
