### PR TITLE
Make Sure Current Working Directory Isn't Root

### DIFF
--- a/checks/agentVersionCheck_test.go
+++ b/checks/agentVersionCheck_test.go
@@ -20,11 +20,16 @@ func TestAgentVersion(t *testing.T) {
 
 	// Error
 	dirname, err := os.Getwd()
-	testFile := dirname + "/opt/python/lib/python3.8/site-packages/newrelic/"
 
+	// We want to make sure our working directory doesn't end up being root
+	assert.NotEqual(t, dirname, "")
+	assert.Nil(t, err)
+
+	testFile := dirname + "/opt/python/lib/python3.8/site-packages/newrelic/"
 	r = runtimeConfigs[Python]
 	r.AgentVersion = "10.1.2"
 	r.layerAgentPaths = []string{testFile}
+
 	os.MkdirAll(testFile, os.ModePerm)
 	defer os.RemoveAll(dirname + "/opt")
 	f, _ := os.Create(testFile + r.agentVersionFile)

--- a/checks/handlerCheck_test.go
+++ b/checks/handlerCheck_test.go
@@ -68,7 +68,12 @@ func TestHandlerCheck(t *testing.T) {
 	assert.EqualError(t, err, "Missing handler file path/to/app.handler (NEW_RELIC_LAMBDA_HANDLER=Undefined)")
 
 	// Success
-	dirname, _ := os.Getwd()
+	dirname, err := os.Getwd()
+
+	// Want to make sure our working directory isn't root
+	assert.NotEqual(t, dirname, "")
+	assert.Nil(t, err)
+
 	handlerPath = dirname + "/var/task"
 	os.MkdirAll(dirname+"/var/task/path/to/", os.ModePerm)
 	os.Create(dirname + "/var/task/path/to/app.js")

--- a/checks/runtimeCheck_test.go
+++ b/checks/runtimeCheck_test.go
@@ -9,7 +9,12 @@ import (
 )
 
 func TestRuntimeCheck(t *testing.T) {
-	dirname, _ := os.Getwd()
+	dirname, err := os.Getwd()
+
+	// Want to make sure working directory isn't root
+	assert.NotEqual(t, dirname, "")
+	assert.Nil(t, err)
+
 	runtimeLookupPath = fmt.Sprintf("%s/%s", dirname, runtimeLookupPath)
 	os.MkdirAll(runtimeLookupPath+"/node", os.ModePerm)
 	defer os.RemoveAll(dirname + "/var")


### PR DESCRIPTION
Also asserts that `os.Getwd()` doesn't return an error.