### PR TITLE
Fix unit tests

### DIFF
--- a/checks/runtimeCheck.go
+++ b/checks/runtimeCheck.go
@@ -28,11 +28,16 @@ func latestAgentTag(r *runtimeConfig) error {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		// The version check HTTP request failed; this doesn't tell us anything
+		util.Debugf("Can't query latest agent version. Request to %v returned status %v", r.agentVersionUrl, resp.StatusCode)
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
-	err = json.Unmarshal([]byte(body), &r)
+	err = json.Unmarshal(body, &r)
 	if err != nil {
 		return err
 	}

--- a/checks/runtimeCheck_test.go
+++ b/checks/runtimeCheck_test.go
@@ -15,7 +15,12 @@ func TestRuntimeCheck(t *testing.T) {
 	assert.NotEqual(t, dirname, "")
 	assert.Nil(t, err)
 
+	oldPath := runtimeLookupPath;
+	defer func() {
+		runtimeLookupPath = oldPath
+	}()
 	runtimeLookupPath = fmt.Sprintf("%s/%s", dirname, runtimeLookupPath)
+
 	os.MkdirAll(runtimeLookupPath+"/node", os.ModePerm)
 	defer os.RemoveAll(dirname + "/var")
 	r, err := checkAndReturnRuntime()


### PR DESCRIPTION
Ideally, tests (and runtime) wouldn't depend on third-party services.
Certainly, the unit tests should not fail when the third-party service
is sending 429 errors