### PR TITLE
Replacing libraries.io with github

### DIFF
--- a/checks/agentVersionCheck.go
+++ b/checks/agentVersionCheck.go
@@ -39,8 +39,8 @@ func agentVersionCheck(conf *config.Configuration, reg *api.RegistrationResponse
 				}
 			}
 			// semver requires a prepended v on version string
-			if semver.Compare("v"+v.Version, "v"+r.AgentVersion) < 0 {
-				return fmt.Errorf("Agent version out of date: %s, in order access up to date features please upgrade to the latest New Relic %s layer that includes agent version %s", v.Version, r.language, r.AgentVersion)
+			if semver.Compare("v"+v.Version, r.AgentVersion) < 0 {
+				return fmt.Errorf("Agent version out of date: v%s, in order access up to date features please upgrade to the latest New Relic %s layer that includes agent version %s", v.Version, r.language, r.AgentVersion)
 			}
 			return nil
 		}

--- a/checks/agentVersionCheck_test.go
+++ b/checks/agentVersionCheck_test.go
@@ -27,7 +27,7 @@ func TestAgentVersion(t *testing.T) {
 
 	testFile := dirname + "/opt/python/lib/python3.8/site-packages/newrelic/"
 	r = runtimeConfigs[Python]
-	r.AgentVersion = "10.1.2"
+	r.AgentVersion = "v10.1.2"
 	r.layerAgentPaths = []string{testFile}
 
 	os.MkdirAll(testFile, os.ModePerm)
@@ -36,7 +36,7 @@ func TestAgentVersion(t *testing.T) {
 	f.WriteString("10.1.0")
 
 	err = agentVersionCheck(&conf, &reg, r)
-	assert.EqualError(t, err, "Agent version out of date: 10.1.0, in order access up to date features please upgrade to the latest New Relic python layer that includes agent version 10.1.2")
+	assert.EqualError(t, err, "Agent version out of date: v10.1.0, in order access up to date features please upgrade to the latest New Relic python layer that includes agent version v10.1.2")
 
 	// Success
 	r.AgentVersion = "10.1.0"

--- a/checks/runtimeCheck.go
+++ b/checks/runtimeCheck.go
@@ -38,7 +38,7 @@ func latestAgentTag(r *runtimeConfig) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 300 || resp.StatusCode == 302 {
+	if resp.StatusCode >= 300 && resp.StatusCode != 302 {
 		// The version check HTTP request failed; this doesn't tell us anything
 		util.Debugf("Can't query latest agent version. Request to %v returned status %v", r.agentVersionUrl, resp.StatusCode)
 		return nil

--- a/checks/runtimeConfig.go
+++ b/checks/runtimeConfig.go
@@ -14,7 +14,7 @@ var (
 )
 
 type runtimeConfig struct {
-	AgentVersion     string `json:"latest_release_number"`
+	AgentVersion     string
 	agentVersionUrl  string
 	agentVersionFile string
 	fileType         string
@@ -40,7 +40,7 @@ var runtimeConfigs = map[Runtime]runtimeConfig{
 		layerAgentPaths:  layerAgentPathNode,
 		vendorAgentPath:  vendorAgentPathNode,
 		agentVersionFile: "package.json",
-		agentVersionUrl:  "https://libraries.io/api/npm/newrelic/",
+		agentVersionUrl:  "https://github.com/newrelic/node-newrelic/releases/latest",
 	},
 	Python: {
 		language:         Python,
@@ -49,6 +49,6 @@ var runtimeConfigs = map[Runtime]runtimeConfig{
 		layerAgentPaths:  layerAgentPathsPython,
 		vendorAgentPath:  vendorAgentPathPython,
 		agentVersionFile: "version.txt",
-		agentVersionUrl:  "https://libraries.io/api/pypi/newrelic/",
+		agentVersionUrl:  "https://github.com/newrelic/newrelic-python-agent/releases/latest",
 	},
 }


### PR DESCRIPTION
Replacing `libraries.io` agent version check with `github`
Github redirects `releases/latest` requests to the latest tag so I'm preventing the redirect here and pulling the tag version from the redirect url. 
https://newrelic.atlassian.net/browse/LAMBDA-1113

