### PR TITLE
fix: More strict license key secret validation

### DIFF
--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/newrelic/newrelic-lambda-extension/util"
@@ -45,6 +46,9 @@ func decodeLicenseKey(rawJson *string) (string, error) {
 	err := json.Unmarshal([]byte(*rawJson), &secrets)
 	if err != nil {
 		return "", err
+	}
+	if secrets.LicenseKey == "" {
+		return "", fmt.Errorf("malformed license key secret; missing \"LicenseKey\" attribute")
 	}
 
 	return secrets.LicenseKey, nil

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -84,3 +84,10 @@ func TestDecodeLicenseKey(t *testing.T) {
 	assert.Empty(t, decoded)
 	assert.Error(t, err)
 }
+
+func TestDecodeLicenseKeyValidButWrong(t *testing.T) {
+	badJson := "{\"some\": \"garbage\"}"
+	decoded, err := decodeLicenseKey(&badJson)
+	assert.Empty(t, decoded)
+	assert.Error(t, err)
+}

--- a/util/extension.go
+++ b/util/extension.go
@@ -2,6 +2,6 @@ package util
 
 const (
 	Name    = "newrelic-lambda-extension"
-	Version = "1.2.1"
+	Version = "1.2.4"
 	Id      = Name + ":" + Version
 )


### PR DESCRIPTION
Customers often mess up the format of the secret. We need to validate it
more carefully.