### PR TITLE
fix: Update .NET sam template with bucket region, update ext versions

### DIFF
--- a/examples/sam/dotnet/deploy.sh
+++ b/examples/sam/dotnet/deploy.sh
@@ -9,7 +9,7 @@ sam build
 
 bucket="newrelic-example-${region}-${accountId}"
 
-aws s3 mb s3://${bucket}
+aws s3 mb --region ${region} s3://${bucket}
 
 sam package --region ${region} --s3-bucket=${bucket} --output-template-file packaged.yaml
 aws cloudformation deploy --region ${region} \

--- a/examples/sam/dotnet/template.yaml
+++ b/examples/sam/dotnet/template.yaml
@@ -25,7 +25,7 @@ Resources:
           # NEW_RELIC_EXTENSION_LOG_LEVEL: DEBUG
       Layers:
         # This layer includes the New Relic Lambda Extension, a sidecar process that sends telemetry.
-        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:451483290750:layer:NewRelicLambdaExtension:11
+        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:451483290750:layer:NewRelicLambdaExtension:12
       Policies:
         # This policy allows the lambda to know the value of the New Relic licence key. We need this so
         # that we can send telemetry back to New Relic

--- a/examples/sam/go/template.yaml
+++ b/examples/sam/go/template.yaml
@@ -28,7 +28,7 @@ Resources:
           # NEW_RELIC_EXTENSION_LOG_LEVEL: DEBUG
       Layers:
         # This layer includes the New Relic Lambda Extension, a sidecar process that sends telemetry
-        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:451483290750:layer:NewRelicLambdaExtension:11
+        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:451483290750:layer:NewRelicLambdaExtension:12
       Policies:
         # This policy allows the lambda to know the value of the New Relic licence key. We need this so
         # that we can send telemetry back to New Relic


### PR DESCRIPTION
We updated the SAM templates to include the region for the s3 bucket...except in the dotnet example. And this updates the extension version to 12. 

Signed-off-by: mrickard <maurice@mauricerickard.com>