### PR TITLE
Maintain lastRequestId across log requests

### DIFF
--- a/util/extension.go
+++ b/util/extension.go
@@ -2,6 +2,6 @@ package util
 
 const (
 	Name    = "newrelic-lambda-extension"
-	Version = "1.2.5"
+	Version = "2.0.2"
 	Id      = Name + ":" + Version
 )


### PR DESCRIPTION
This is a bit risky, in that it assumes that we'll get requests in order. I don't think we can do better though, as function log records just don't contain the requestId.