### PR TITLE
Add required envs for lambda extensions in TF examples

### DIFF
--- a/examples/terraform/nodejs/main.tf
+++ b/examples/terraform/nodejs/main.tf
@@ -42,6 +42,10 @@ resource "aws_lambda_function" "newrelic_terraform_example_nodejs_function" {
       # For the instrumentation handler to invoke your real handler, we need this value
       NEW_RELIC_LAMBDA_HANDLER = var.lambda_function_handler
       NEW_RELIC_ACCOUNT_ID     = var.newrelic_account_id
+      # Enable NR Lambda extension if the telemetry data are ingested via lambda extension
+      NEW_RELIC_LAMBDA_EXTENSION_ENABLED = true
+      # Enable Distributed tracing for in-depth monitoring of transactions in lambda (Optional)
+      NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = true
     }
   }
   # This layer includes the New Relic Lambda Extension, a sidecar process that sends telemetry,

--- a/examples/terraform/python/main.tf
+++ b/examples/terraform/python/main.tf
@@ -42,6 +42,10 @@ resource "aws_lambda_function" "newrelic_terraform_example_python_function" {
       # For the instrumentation handler to invoke your real handler, we need this value
       NEW_RELIC_LAMBDA_HANDLER = var.lambda_function_handler
       NEW_RELIC_ACCOUNT_ID     = var.newrelic_account_id
+      # Enable NR Lambda extension if the telemetry data are ingested via lambda extension
+      NEW_RELIC_LAMBDA_EXTENSION_ENABLED = true
+      # Enable Distributed tracing for in-depth monitoring of transactions in lambda (Optional)
+      NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = true
     }
   }
   # This layer includes the New Relic Lambda Extension, a sidecar process that sends telemetry,


### PR DESCRIPTION
Added **NEW_RELIC_LAMBDA_EXTENSION_ENABLED** environment variables in TF examples - if the ingestion for the instrumented function's telemetry data is shipped via newrelic-lambda extension. 