### PR TITLE
fix: Handle log event.Record that's a string instead of a map

### DIFF
--- a/lambda/logserver/logserver.go
+++ b/lambda/logserver/logserver.go
@@ -99,7 +99,7 @@ func formatReport(metrics map[string]interface{}) string {
 	return ret
 }
 
-var requestIdRegExp, _ = regexp.Compile("RequestId: ([a-f0-9-]+)")
+var requestIdRegExp, _ = regexp.Compile("RequestId: ([a-zA-Z0-9-]+)")
 
 func (ls *LogServer) handler(res http.ResponseWriter, req *http.Request) {
 	defer util.Close(req.Body)

--- a/lambda/logserver/logserver.go
+++ b/lambda/logserver/logserver.go
@@ -125,7 +125,7 @@ func (ls *LogServer) handler(res http.ResponseWriter, req *http.Request) {
 			case map[string]interface{}:
 				ls.lastRequestId = event.Record.(map[string]interface{})["requestId"].(string)
 			case string:
-				recordString := fmt.Sprintf("%s", event.Record)
+				recordString := event.Record.(string)
 				ls.lastRequestId = requestIdRegExp.FindStringSubmatch(recordString)[1]
 			}
 			ls.lastRequestIdLock.Unlock()

--- a/lambda/logserver/logserver.go
+++ b/lambda/logserver/logserver.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"regexp"
 	"strconv"
 	"sync"
 	"time"
@@ -26,11 +27,11 @@ type LogLine struct {
 }
 
 type LogServer struct {
-	listenString    string
-	server          *http.Server
-	platformLogChan chan LogLine
-	functionLogChan chan []LogLine
-	lastRequestId   string
+	listenString      string
+	server            *http.Server
+	platformLogChan   chan LogLine
+	functionLogChan   chan []LogLine
+	lastRequestId     string
 	lastRequestIdLock *sync.Mutex
 }
 
@@ -98,6 +99,8 @@ func formatReport(metrics map[string]interface{}) string {
 	return ret
 }
 
+var requestIdRegExp, _ = regexp.Compile("RequestId: ([a-f0-9-]+)")
+
 func (ls *LogServer) handler(res http.ResponseWriter, req *http.Request) {
 	defer util.Close(req.Body)
 
@@ -118,7 +121,13 @@ func (ls *LogServer) handler(res http.ResponseWriter, req *http.Request) {
 		switch event.Type {
 		case "platform.start":
 			ls.lastRequestIdLock.Lock()
-			ls.lastRequestId = event.Record.(map[string]interface{})["requestId"].(string)
+			switch event.Record.(type) {
+			case map[string]interface{}:
+				ls.lastRequestId = event.Record.(map[string]interface{})["requestId"].(string)
+			case string:
+				recordString := fmt.Sprintf("%s", event.Record)
+				ls.lastRequestId = requestIdRegExp.FindStringSubmatch(recordString)[1]
+			}
 			ls.lastRequestIdLock.Unlock()
 		case "platform.report":
 			record := event.Record.(map[string]interface{})
@@ -171,10 +180,10 @@ func startInternal(host string) (*LogServer, error) {
 	server := &http.Server{}
 
 	logServer := &LogServer{
-		listenString:    listener.Addr().String(),
-		server:          server,
-		platformLogChan: make(chan LogLine, platformLogBufferSize),
-		functionLogChan: make(chan []LogLine),
+		listenString:      listener.Addr().String(),
+		server:            server,
+		platformLogChan:   make(chan LogLine, platformLogBufferSize),
+		functionLogChan:   make(chan []LogLine),
 		lastRequestIdLock: &sync.Mutex{},
 	}
 

--- a/lambda/logserver/logserver_test.go
+++ b/lambda/logserver/logserver_test.go
@@ -34,6 +34,23 @@ func TestLogServer(t *testing.T) {
 		},
 	}
 
+	fmt.Println("testEvents")
+	fmt.Println(testEvents)
+
+	platformStart := api.LogEvent{
+		Time:   time.Now().Add(-100 * time.Millisecond),
+		Type:   "platform.start",
+		Record: "RequestId: abcdef01-a2b3-4321-cd89-0123456789ab",
+	}
+	fmt.Println("platformStart")
+	fmt.Println(platformStart)
+
+	testEvents = append(testEvents, platformStart)
+
+	fmt.Println("============ testEvents after append ===========")
+	fmt.Println(testEvents)
+	fmt.Println("============ / testEvents after append ===========")
+
 	testEventBytes, err := json.Marshal(testEvents)
 	assert.NoError(t, err)
 
@@ -50,8 +67,15 @@ func TestLogServer(t *testing.T) {
 
 	logLines := logs.PollPlatformChannel()
 
-	assert.Equal(t, 1, len(logLines))
+	fmt.Println("log server response")
+	fmt.Println(res)
+	fmt.Println("log lines")
+	fmt.Println(logLines)
+
+	assert.Equal(t, 2, len(logLines))
 	assert.Equal(t, "REPORT RequestId: testRequestId\tDuration: 25.30 ms\tBilled Duration: 100 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tInit Duration: 202.00 ms", string(logLines[0].Content))
+
+	assert.Equal(t, "START RequestId: abcdef01-a2b3-4321-cd89-0123456789ab", string(logLines[1].Content))
 
 	assert.Nil(t, logs.Close())
 }
@@ -62,15 +86,15 @@ func TestFunctionLogs(t *testing.T) {
 
 	testEvents := []api.LogEvent{
 		{
-			Time: time.Now().Add(-100*time.Millisecond),
+			Time: time.Now().Add(-100 * time.Millisecond),
 			Type: "platform.start",
 			Record: map[string]interface{}{
 				"requestId": "testRequestId",
 			},
 		},
 		{
-			Time: time.Now().Add(-50*time.Millisecond),
-			Type: "function",
+			Time:   time.Now().Add(-50 * time.Millisecond),
+			Type:   "function",
 			Record: "log line 1",
 		},
 	}
@@ -99,8 +123,8 @@ func TestFunctionLogs(t *testing.T) {
 
 	testEvents2 := []api.LogEvent{
 		{
-			Time: time.Now().Add(500*time.Millisecond),
-			Type: "function",
+			Time:   time.Now().Add(500 * time.Millisecond),
+			Type:   "function",
 			Record: "log line 2",
 		},
 	}

--- a/util/extension.go
+++ b/util/extension.go
@@ -2,6 +2,6 @@ package util
 
 const (
 	Name    = "newrelic-lambda-extension"
-	Version = "2.0.2"
+	Version = "2.0.3"
 	Id      = Name + ":" + Version
 )


### PR DESCRIPTION
Making this a draft to solicit suggestions for a better way to handle this scenario.

There's a user report of an extension panic in a Go-instrumented Lambda, when the logserver attempts to parse the platform.start log line for requestId--this particular message's `record` field is apparently a string, rather than the expected map. Log messages show this type mismatch, and the [Lambda Logs API doc](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-logs-api.html) shows some examples (such as platform.fault) for which record can be a string. 

This PR attempts to handle either case. 

https://newrelic.atlassian.net/browse/LAMBDA-1321

Signed-off-by: mrickard <maurice@mauricerickard.com>