### PR TITLE
fix: Adding python 3.9 path to runtime config.

### DIFF
--- a/checks/runtime_config.go
+++ b/checks/runtime_config.go
@@ -7,6 +7,7 @@ var (
 		"/opt/python/lib/python3.6/site-packages/newrelic",
 		"/opt/python/lib/python3.7/newrelic",
 		"/opt/python/lib/python3.8/site-packages/newrelic",
+		"/opt/python/lib/python3.9/site-packages/newrelic",
 	}
 	vendorAgentPathNode   = "/var/task/node_modules/newrelic"
 	vendorAgentPathPython = "/var/task/newrelic"


### PR DESCRIPTION
This very small commit should be all that's needed to add Python 3.9 support to the Extension.

Signed-off-by: mrickard <maurice@mauricerickard.com>