### PR TITLE
Harvest fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,6 @@ test:
 
 coverage:
 	./coverage.sh
+
+publish: zip-x86_64
+	aws lambda publish-layer-version --no-cli-pager --layer-name newrelic-lambda-extension-x86_64 --zip-file fileb:///tmp/newrelic-lambda-extension.x86_64.zip

--- a/examples/sam/node/deploy.sh
+++ b/examples/sam/node/deploy.sh
@@ -13,7 +13,7 @@ aws s3 mb --region "${region}" "s3://${bucket}"
 
 sam package --region "${region}" --s3-bucket "${bucket}" --output-template-file packaged.yaml
 
-sam deploy \
+aws cloudformation deploy \
 	--region "${region}" \
 	--template-file packaged.yaml \
 	--stack-name NewrelicExampleNode \

--- a/examples/sam/node/template.yaml
+++ b/examples/sam/node/template.yaml
@@ -18,18 +18,18 @@ Resources:
       FunctionName: newrelic-example-nodejs
       # The handler for your function needs to be the one provided by the instrumentation layer, below.
       Handler: newrelic-lambda-wrapper.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Environment:
         Variables:
           # For the instrumentation handler to invoke your real handler, we need this value
           NEW_RELIC_LAMBDA_HANDLER: app.lambdaHandler
           NEW_RELIC_ACCOUNT_ID: !Sub ${NRAccountId}
           # NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS: true
-          # NEW_RELIC_EXTENSION_LOG_LEVEL: DEBUG
+          NEW_RELIC_EXTENSION_LOG_LEVEL: DEBUG
       Layers:
         # This layer includes the New Relic Lambda Extension, a sidecar process that sends telemetry,
         # as well as the New Relic Agent for Node.js, and a handler wrapper that makes integration easy.
-        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:451483290750:layer:NewRelicNodeJS12X:44
+        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:451483290750:layer:NewRelicNodeJS14X:36
       Policies:
         # This policy allows the lambda to know the value of the New Relic licence key. We need this so
         # that we can send telemetry back to New Relic

--- a/telemetry/batch.go
+++ b/telemetry/batch.go
@@ -53,7 +53,6 @@ func (b *Batch) AddTelemetry(requestId string, telemetry []byte) *Invocation {
 // Harvest checks to see if it's time to harvest, and returns harvested invocations, or nil. The caller must ensure that harvested invocations are sent.
 func (b *Batch) Harvest(now time.Time) []*Invocation {
 	if len(b.invocations) == 0 {
-		b.lastHarvest = now
 		return nil
 	}
 
@@ -84,8 +83,10 @@ func (b *Batch) aggressiveHarvest(now time.Time) []*Invocation {
 			delete(b.invocations, k)
 		}
 	}
-	b.lastHarvest = now
-	b.eldest = epochStart
+	if len(ret) > 0 {
+		b.lastHarvest = now
+		b.eldest = epochStart
+	}
 	util.Debugf("Aggressive harvest yielded %d invocations\n", len(ret))
 	return ret
 }
@@ -103,7 +104,9 @@ func (b *Batch) ripeHarvest(now time.Time) []*Invocation {
 		}
 	}
 	b.eldest = newEldest
-	b.lastHarvest = now
+	if len(ret) > 0 {
+		b.lastHarvest = now
+	}
 	util.Debugf("Ripe harvest yielded %d invocations\n", len(ret))
 	return ret
 }

--- a/telemetry/batch_test.go
+++ b/telemetry/batch_test.go
@@ -33,8 +33,7 @@ func TestMissingInvocation(t *testing.T) {
 func TestWithInvocationRipeHarvest(t *testing.T) {
 	batch := NewBatch(ripe, rot)
 
-	// To test a ripe harvest, we need to have done at least one harvest cycle before
-	batch.Harvest(requestStart)
+	batch.lastHarvest = requestStart
 
 	batch.AddInvocation(testRequestId, requestStart)
 	batch.AddInvocation(testRequestId2, requestStart.Add(100*time.Millisecond))

--- a/telemetry/batch_test.go
+++ b/telemetry/batch_test.go
@@ -30,6 +30,34 @@ func TestMissingInvocation(t *testing.T) {
 	assert.Nil(t, invocation)
 }
 
+func TestEmptyHarvest(t *testing.T) {
+	batch := NewBatch(ripe, rot)
+	res := batch.Harvest(requestStart)
+
+	assert.Nil(t, res)
+}
+
+func TestEmptyRotHarvest(t *testing.T) {
+	batch := NewBatch(ripe, rot)
+
+	batch.AddInvocation("test", requestStart)
+
+	res := batch.Harvest(requestStart)
+
+	assert.Empty(t, res)
+}
+
+func TestEmptyRipeHarvest(t *testing.T) {
+	batch := NewBatch(ripe, rot)
+
+	batch.lastHarvest = requestStart.Add(-ripe)
+	batch.AddInvocation("test", requestStart)
+
+	res := batch.Harvest(requestStart)
+
+	assert.Empty(t, res)
+}
+
 func TestWithInvocationRipeHarvest(t *testing.T) {
 	batch := NewBatch(ripe, rot)
 

--- a/util/extension.go
+++ b/util/extension.go
@@ -2,6 +2,6 @@ package util
 
 const (
 	Name    = "newrelic-lambda-extension"
-	Version = "2.0.6"
+	Version = "2.1.0"
 	Id      = Name + ":" + Version
 )


### PR DESCRIPTION
The most critical aspect of this fix is subtle: we don't get invoked function ARNs in shutdown events, and we can't send telemetry without one of those (LLC rejects it). We were losing all our buffered telemetry at shutdown because of this. 

I've also simplified timeout handling, and moved the happy-path telemetry send in parallel with our wait on the named pipe. In the normal case of a steady invocation rate, this will put the telemetry POST in parallel with the handler processing, reducing our impact on the function lifecycle. I've also eliminated a case where we could have lost telemetry unnecessarily due to an invocation timeout. 

Finally, `defer` in a loop is not a great idea. It doesn't really accomplish what you want, and it does leak memory. 