### PR TITLE
doc: Fixes Readmes, Adds CF Constraint

### DIFF
--- a/examples/sam/distributedtracing/template.yml
+++ b/examples/sam/distributedtracing/template.yml
@@ -32,6 +32,8 @@ Resources:
       CodeUri: python/rest_handler/
       Handler: newrelic_lambda_wrapper.handler
       Runtime: python3.8
+      # Currently, we don't support Image based PackageType
+      PackageType: Zip
       Environment:
         Variables:
           # For the instrumentation handler to invoke your real handler, we need this value
@@ -77,6 +79,8 @@ Resources:
       Runtime: nodejs12.x
       CodeUri: node/
       Handler: newrelic-lambda-wrapper.handler
+      # Currently, we don't support Image based PackageType
+      PackageType: Zip
       Environment:
         Variables:
           # For the instrumentation handler to invoke your real handler, we need this value
@@ -120,6 +124,8 @@ Resources:
       Handler: dtsnsexample.App::handleRequest
       Runtime: java11
       MemorySize: 512
+      # Currently, we don't support Image based PackageType
+      PackageType: Zip
       Environment:
         Variables:
           NEW_RELIC_ACCOUNT_ID: !Sub ${NRAccountId}

--- a/examples/sam/java/README.md
+++ b/examples/sam/java/README.md
@@ -16,7 +16,7 @@ know that all the telemetry plumbing is connected correctly.
 - The [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
 - [newrelic-lambda](https://github.com/newrelic/newrelic-lambda-cli#installation) CLI tool
 
-Make sure you've run the `newrelic-lambda install` command in your
+Make sure you've run the `newrelic-lambda integrations install` command in your
 AWS Region, and included the `--enable-license-key-secret` flag.
 
 ### deploy script

--- a/examples/sam/java/template.yaml
+++ b/examples/sam/java/template.yaml
@@ -20,6 +20,8 @@ Resources:
       # Lambda Extensions are not supported in the "java8" runtime.
       Runtime: java11
       MemorySize: 512
+      # Currently, we don't support Image based PackageType
+      PackageType: Zip
       Environment:
         Variables:
           NEW_RELIC_LAMBDA_HANDLER: com.newrelic.lambda.example.App::handleRequest
@@ -44,6 +46,8 @@ Resources:
       Handler: com.newrelic.java.HandlerWrapper::handleStreamsRequest
       Runtime: java11
       MemorySize: 512
+      # Currently, we don't support Image based PackageType
+      PackageType: Zip
       Environment:
         Variables:
           NEW_RELIC_LAMBDA_HANDLER: com.newrelic.lambda.example.Stream::handleRequest

--- a/examples/sam/node/README.md
+++ b/examples/sam/node/README.md
@@ -16,7 +16,7 @@ know that all the telemetry plumbing is connected correctly.
 - The [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
 - [newrelic-lambda](https://github.com/newrelic/newrelic-lambda-cli#installation) CLI tool
 
-Make sure you've run the `newrelic-lambda install` command in your
+Make sure you've run the `newrelic-lambda integrations install` command in your
 AWS Region, and included the `--enable-license-key-secret` flag.
 
 ### deploy script

--- a/examples/sam/node/template.yaml
+++ b/examples/sam/node/template.yaml
@@ -19,6 +19,8 @@ Resources:
       # The handler for your function needs to be the one provided by the instrumentation layer, below.
       Handler: newrelic-lambda-wrapper.handler
       Runtime: nodejs14.x
+      # Currently, we don't support Image based PackageType
+      PackageType: Zip
       Environment:
         Variables:
           # For the instrumentation handler to invoke your real handler, we need this value

--- a/examples/sam/python/README.md
+++ b/examples/sam/python/README.md
@@ -16,7 +16,7 @@ know that all the telemetry plumbing is connected correctly.
 - The [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
 - [newrelic-lambda](https://github.com/newrelic/newrelic-lambda-cli#installation) CLI tool
 
-Make sure you've run the `newrelic-lambda install` command in your
+Make sure you've run the `newrelic-lambda integrations install` command in your
 AWS Region, and included the `--enable-license-key-secret` flag.
 
 ### deploy script

--- a/examples/sam/python/template.yaml
+++ b/examples/sam/python/template.yaml
@@ -19,6 +19,8 @@ Resources:
       # The handler for your function needs to be the one provided by the instrumentation layer, below.
       Handler: newrelic_lambda_wrapper.handler
       Runtime: python3.8
+      # Currently, we don't support Image based PackageType
+      PackageType: Zip
       Environment:
         Variables:
           # For the instrumentation handler to invoke your real handler, we need this value

--- a/examples/terraform/nodejs/README.md
+++ b/examples/terraform/nodejs/README.md
@@ -15,7 +15,7 @@ know that all the telemetry plumbing is connected correctly.
 - The [Terraform CLI](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 - [newrelic-lambda](https://github.com/newrelic/newrelic-lambda-cli#installation) CLI tool
 
-Make sure you've run the `newrelic-lambda install` command in your
+Make sure you've run the `newrelic-lambda integrations install` command in your
 AWS Region, and included the `--enable-license-key-secret` flag.
 
 ### deploy script

--- a/examples/terraform/python/README.md
+++ b/examples/terraform/python/README.md
@@ -15,7 +15,7 @@ know that all the telemetry plumbing is connected correctly.
 - The [Terraform CLI](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 - [newrelic-lambda](https://github.com/newrelic/newrelic-lambda-cli#installation) CLI tool
 
-Make sure you've run the `newrelic-lambda install` command in your
+Make sure you've run the `newrelic-lambda integrations install` command in your
 AWS Region, and included the `--enable-license-key-secret` flag.
 
 ### deploy script


### PR DESCRIPTION
* fixes readmes, instructions didn't specify integrations as a sub command must be used
* adds cloudformation constraints to templates to advise that Image types are not supported

Resolves: fix/doc-and-small-adjs