### PR TITLE
created new env var used to disable extension logs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,7 +49,13 @@ func ConfigurationFromEnvironment() *Configuration {
 	if extensionEnabledOverride && strings.ToLower(enabledStr) == "false" {
 		extensionEnabled = false
 	}
-	ret := &Configuration{ExtensionEnabled: extensionEnabled, LogsEnabled: true}
+
+	logsEnabled := true
+	if logsEnabledOverride && strings.ToLower(logsEnabledStr) == "false" {
+		logsEnabled = false
+	}
+
+	ret := &Configuration{ExtensionEnabled: extensionEnabled, LogsEnabled: logsEnabled}
 
 	if lkOverride {
 		ret.LicenseKey = licenseKey
@@ -111,10 +117,6 @@ func ConfigurationFromEnvironment() *Configuration {
 
 	if sendFunctionLogsOverride && sendFunctionLogsStr == "true" {
 		ret.SendFunctionLogs = true
-	}
-
-	if logsEnabledOverride && logsEnabledStr == "false" {
-		ret.LogsEnabled = false
 	}
 
 	return ret

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type Configuration struct {
 	RipeMillis         uint32
 	RotMillis          uint32
 	LogLevel           string
+	LogsEnabled        bool
 	SendFunctionLogs   bool
 	LogServerHost      string
 }
@@ -40,6 +41,7 @@ func ConfigurationFromEnvironment() *Configuration {
 	ripeMillisStr, ripeMillisOverride := os.LookupEnv("NEW_RELIC_HARVEST_RIPE_MILLIS")
 	rotMillisStr, rotMillisOverride := os.LookupEnv("NEW_RELIC_HARVEST_ROT_MILLIS")
 	logLevelStr, logLevelOverride := os.LookupEnv("NEW_RELIC_EXTENSION_LOG_LEVEL")
+	logsEnabledStr, logsEnabledOverride := os.LookupEnv("NEW_RELIC_EXTENSION_LOGS_ENABLED")
 	sendFunctionLogsStr, sendFunctionLogsOverride := os.LookupEnv("NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS")
 	logServerHostStr, logServerHostOverride := os.LookupEnv("NEW_RELIC_LOG_SERVER_HOST")
 
@@ -47,7 +49,7 @@ func ConfigurationFromEnvironment() *Configuration {
 	if extensionEnabledOverride && strings.ToLower(enabledStr) == "false" {
 		extensionEnabled = false
 	}
-	ret := &Configuration{ExtensionEnabled: extensionEnabled}
+	ret := &Configuration{ExtensionEnabled: extensionEnabled, LogsEnabled: true}
 
 	if lkOverride {
 		ret.LicenseKey = licenseKey
@@ -105,6 +107,14 @@ func ConfigurationFromEnvironment() *Configuration {
 
 	if sendFunctionLogsOverride && sendFunctionLogsStr == "true" {
 		ret.SendFunctionLogs = true
+	}
+
+	if sendFunctionLogsOverride && sendFunctionLogsStr == "true" {
+		ret.SendFunctionLogs = true
+	}
+
+	if logsEnabledOverride && logsEnabledStr == "false" {
+		ret.LogsEnabled = false
 	}
 
 	return ret

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,6 +14,7 @@ func TestConfigurationFromEnvironmentZero(t *testing.T) {
 		RipeMillis:       DefaultRipeMillis,
 		RotMillis:        DefaultRotMillis,
 		LogLevel:         DefaultLogLevel,
+		LogsEnabled:      true,
 		NRHandler:        EmptyNRWrapper,
 		LogServerHost:    defaultLogServerHost,
 	}
@@ -26,6 +27,7 @@ func TestConfigurationFromEnvironment(t *testing.T) {
 	conf := ConfigurationFromEnvironment()
 
 	assert.Equal(t, conf.ExtensionEnabled, true)
+	assert.Equal(t, conf.LogsEnabled, true)
 
 	os.Setenv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED", "false")
 	os.Setenv("NEW_RELIC_LAMBDA_HANDLER", "newrelic_lambda_wrapper.handler")
@@ -37,6 +39,7 @@ func TestConfigurationFromEnvironment(t *testing.T) {
 	os.Setenv("NEW_RELIC_HARVEST_ROT_MILLIS", "0")
 	os.Setenv("NEW_RELIC_EXTENSION_LOG_LEVEL", "DEBUG")
 	os.Setenv("NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS", "true")
+	os.Setenv("NEW_RELIC_EXTENSION_LOGS_ENABLED", "false")
 
 	defer func() {
 		os.Unsetenv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED")
@@ -49,6 +52,7 @@ func TestConfigurationFromEnvironment(t *testing.T) {
 		os.Unsetenv("NEW_RELIC_HARVEST_ROT_MILLIS")
 		os.Unsetenv("NEW_RELIC_EXTENSION_LOG_LEVEL")
 		os.Unsetenv("NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS")
+		os.Unsetenv("NEW_RELIC_EXTENSION_LOGS_ENABLED")
 	}()
 
 	conf = ConfigurationFromEnvironment()
@@ -63,6 +67,7 @@ func TestConfigurationFromEnvironment(t *testing.T) {
 	assert.Equal(t, uint32(DefaultRotMillis), conf.RotMillis)
 	assert.Equal(t, "DEBUG", conf.LogLevel)
 	assert.Equal(t, true, conf.SendFunctionLogs)
+	assert.Equal(t, false, conf.LogsEnabled)
 }
 
 func TestConfigurationFromEnvironmentSecretId(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	conf := config.ConfigurationFromEnvironment()
 
 	// Optionally enable debug logging, disabled by default
-	util.ConfigLogger(conf.LogLevel == config.DebugLogLevel)
+	util.ConfigLogger(conf.LogsEnabled, conf.LogLevel == config.DebugLogLevel)
 
 	// Extensions must register
 	registrationClient := client.New(http.Client{})

--- a/util/logger.go
+++ b/util/logger.go
@@ -3,67 +3,82 @@ package util
 import "log"
 
 var logger = Logger{
+	isEnabled:      true,
 	isDebugEnabled: false,
 }
 
 type Logger struct {
+	isEnabled      bool
 	isDebugEnabled bool
 }
 
-func ConfigLogger(isDebugEnabled bool) {
+func ConfigLogger(logsEnabled bool, isDebugEnabled bool) {
 	// Go Logging config
 	log.SetPrefix("[NR_EXT] ")
 	log.SetFlags(0)
 
 	log.Println("New Relic Lambda Extension starting up")
 
+	logger.isEnabled = logsEnabled
 	logger.isDebugEnabled = isDebugEnabled
 }
 
 func (l Logger) Debugf(format string, v ...interface{}) {
-	if l.isDebugEnabled {
+	if l.isEnabled && l.isDebugEnabled {
 		log.Printf(format, v...)
 	}
 }
 
 func (l Logger) Debugln(v ...interface{}) {
-	if l.isDebugEnabled {
+	if l.isEnabled && l.isDebugEnabled {
 		log.Println(v...)
 	}
 }
 
 func (l Logger) Logf(format string, v ...interface{}) {
-	log.Printf(format, v...)
+	if l.isEnabled {
+		log.Printf(format, v...)
+	}
 }
 
 func (l Logger) Logln(v ...interface{}) {
-	log.Println(v...)
+	if l.isEnabled {
+		log.Println(v...)
+	}
 }
 
 func Debugf(format string, v ...interface{}) {
-	if logger.isDebugEnabled {
+	if logger.isEnabled && logger.isDebugEnabled {
 		log.Printf(format, v...)
 	}
 }
 
 func Debugln(v ...interface{}) {
-	if logger.isDebugEnabled {
+	if logger.isEnabled && logger.isDebugEnabled {
 		log.Println(v...)
 	}
 }
 
 func Logf(format string, v ...interface{}) {
-	log.Printf(format, v...)
+	if logger.isEnabled {
+		log.Printf(format, v...)
+	}
 }
 
 func Logln(v ...interface{}) {
-	log.Println(v...)
+	if logger.isEnabled {
+		log.Println(v...)
+	}
 }
 
 func Fatal(v ...interface{}) {
-	log.Fatal(v...)
+	if logger.isEnabled {
+		log.Fatal(v...)
+	}
 }
 
 func Panic(v ...interface{}) {
-	log.Panic(v...)
+	if logger.isEnabled {
+		log.Panic(v...)
+	}
 }


### PR DESCRIPTION
## Background
In addition to new relic, we also ship logs to an ELK stack.  We've noticed a large number of logs similar to the following in our lambdas:
`[NR_EXT] Sent 1/1 New Relic payload batches with 1 log events successfully in 331935.777ms (63ms to transmit 4.8kB)`

## Details
The goal of this PR is to allow users to disable extension logs.  This PR adds an environment variable `NEW_RELIC_EXTENSION_LOGS_ENABLED`.  The default behavior if unset is `true` (enabled).  When set to false, calls to logging functions will be ignored.  I've also added tests for this feature as well.  