### PR TITLE
Fewer retries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ zip-arm64: dist-arm64
 	zip -r /tmp/newrelic-lambda-extension.arm64.zip preview-extensions-ggqizro707 extensions
 
 test:
+	@echo "Normal tests"
+	go test ./...
+	@echo "\n\nRace check"
 	go test -race ./...
 
 coverage:

--- a/checks/runtime_check_test.go
+++ b/checks/runtime_check_test.go
@@ -1,8 +1,10 @@
+//go:build !race
+// +build !race
+
 package checks
 
 import (
 	"bytes"
-	"errors"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -11,12 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
-
-type mockClientError struct{}
-
-func (c *mockClientError) Get(string) (*http.Response, error) {
-	return nil, errors.New("Something went wrong")
-}
 
 type mockClientRedirect struct{}
 

--- a/checks/startup_check_test.go
+++ b/checks/startup_check_test.go
@@ -2,7 +2,9 @@ package checks
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/newrelic/newrelic-lambda-extension/config"
@@ -10,6 +12,12 @@ import (
 	"github.com/newrelic/newrelic-lambda-extension/lambda/logserver"
 	"github.com/stretchr/testify/assert"
 )
+
+type mockClientError struct{}
+
+func (c *mockClientError) Get(string) (*http.Response, error) {
+	return nil, errors.New("Something went wrong")
+}
 
 type TestLogSender struct {
 	sent []logserver.LogLine

--- a/lambda/logserver/logserver_test.go
+++ b/lambda/logserver/logserver_test.go
@@ -1,3 +1,6 @@
+//go:build !race
+// +build !race
+
 package logserver
 
 import (

--- a/main_test.go
+++ b/main_test.go
@@ -1,3 +1,6 @@
+//go:build !race
+// +build !race
+
 package main
 
 import (


### PR DESCRIPTION
Instead of shipping telemetry in a goroutine and relying on frequent invocations to successfully manage HTTP requests across invocations, just do the HTTP requests synchronously. This will reduce spurious retries, which can result in duplicate telemetry.