### PR TITLE
Synchronize Batch with Reader Writer Lock

### DIFF
--- a/telemetry/batch.go
+++ b/telemetry/batch.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"math"
+	"sync"
 	"time"
 
 	"github.com/newrelic/newrelic-lambda-extension/util"
@@ -12,12 +13,13 @@ var epochStart = time.Unix(0, 0)
 
 // Batch represents the unsent invocations and their telemetry, along with timing data.
 type Batch struct {
+	extractTraceID  bool
 	lastHarvest     time.Time
 	eldest          time.Time
-	invocations     map[string]*Invocation
 	ripeDuration    time.Duration
 	veryOldDuration time.Duration
-	extractTraceID  bool
+	invocations     map[string]*Invocation
+	lock            sync.RWMutex
 }
 
 // NewBatch constructs a new batch.
@@ -35,12 +37,18 @@ func NewBatch(ripeMillis, rotMillis int64, extractTraceID bool) *Batch {
 
 // AddInvocation should be called just after the next API response. It creates the Invocation record so that we can attach telemetry later.
 func (b *Batch) AddInvocation(requestId string, start time.Time) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	invocation := NewInvocation(requestId, start)
 	b.invocations[requestId] = &invocation
 }
 
 // AddTelemetry attaches telemetry to an existing Invocation, identified by requestId
 func (b *Batch) AddTelemetry(requestId string, telemetry []byte) *Invocation {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	inv, ok := b.invocations[requestId]
 	if ok {
 		inv.Telemetry = append(inv.Telemetry, telemetry)
@@ -64,6 +72,9 @@ func (b *Batch) AddTelemetry(requestId string, telemetry []byte) *Invocation {
 
 // Harvest checks to see if it's time to harvest, and returns harvested invocations, or nil. The caller must ensure that harvested invocations are sent.
 func (b *Batch) Harvest(now time.Time) []*Invocation {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	if len(b.invocations) == 0 {
 		return nil
 	}
@@ -83,6 +94,9 @@ func (b *Batch) Harvest(now time.Time) []*Invocation {
 
 // Close aggressively harvests all telemetry from the Batch. The Batch is no longer valid.
 func (b *Batch) Close() []*Invocation {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return b.aggressiveHarvest(time.Now())
 }
 
@@ -123,7 +137,20 @@ func (b *Batch) ripeHarvest(now time.Time) []*Invocation {
 	return ret
 }
 
+// RetrieveTraceID looks up a trace ID using the provided request ID
+func (b *Batch) RetrieveTraceID(requestId string) string {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	inv, ok := b.invocations[requestId]
+	if ok {
+		return inv.TraceId
+	}
+	return ""
+}
+
 // An Invocation holds telemetry for a request, and knows when the request began.
+// Invocations are parts of a Batch, and should only be used by the batch object.
 type Invocation struct {
 	Start     time.Time
 	RequestId string
@@ -148,13 +175,4 @@ func (inv *Invocation) IsRipe() bool {
 // IsEmpty is true when the invocation has no telemetry. The invocation has begun, but has received no agent payload, nor platform logs.
 func (inv *Invocation) IsEmpty() bool {
 	return len(inv.Telemetry) == 0
-}
-
-// RetrieveTraceID looks up a trace ID using the provided request ID
-func (b *Batch) RetrieveTraceID(requestId string) string {
-	inv, ok := b.invocations[requestId]
-	if ok {
-		return inv.TraceId
-	}
-	return ""
 }


### PR DESCRIPTION
Avoid runtime panics and unexpected changes in state by synchronizing access to the underlying data in a batch using a reader writer lock. This will have slight performance impact, but will prevent applications from being crashed.