### PR TITLE
Smarter Timeouts

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,7 @@ func TestConfigurationFromEnvironmentZero(t *testing.T) {
 		LogsEnabled:      true,
 		NRHandler:        EmptyNRWrapper,
 		LogServerHost:    defaultLogServerHost,
+		ClientTimeout:    DefaultClientTimeout,
 	}
 	assert.Equal(t, expected, conf)
 }
@@ -40,6 +41,7 @@ func TestConfigurationFromEnvironment(t *testing.T) {
 	os.Setenv("NEW_RELIC_EXTENSION_LOG_LEVEL", "DEBUG")
 	os.Setenv("NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS", "true")
 	os.Setenv("NEW_RELIC_EXTENSION_LOGS_ENABLED", "false")
+	os.Setenv("NEW_RELIC_DATA_COLLECTION_TIMEOUT", "5s")
 
 	defer func() {
 		os.Unsetenv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED")
@@ -53,6 +55,7 @@ func TestConfigurationFromEnvironment(t *testing.T) {
 		os.Unsetenv("NEW_RELIC_EXTENSION_LOG_LEVEL")
 		os.Unsetenv("NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS")
 		os.Unsetenv("NEW_RELIC_EXTENSION_LOGS_ENABLED")
+		os.Unsetenv("NEW_RELIC_DATA_COLLECTION_TIMEOUT")
 	}()
 
 	conf = ConfigurationFromEnvironment()

--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func main() {
 	}
 
 	// Init the telemetry sending client
-	telemetryClient := telemetry.New(registrationResponse.FunctionName, licenseKey, conf.TelemetryEndpoint, conf.LogEndpoint, batch, conf.CollectTraceID)
+	telemetryClient := telemetry.New(registrationResponse.FunctionName, licenseKey, conf.TelemetryEndpoint, conf.LogEndpoint, batch, conf.CollectTraceID, conf.ClientTimeout)
 	telemetryChan, err := telemetry.InitTelemetryChannel()
 	if err != nil {
 		err2 := invocationClient.InitError(ctx, "telemetryClient.init", err)

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -41,7 +41,7 @@ type Client struct {
 // New creates a telemetry client with sensible defaults
 func New(functionName string, licenseKey string, telemetryEndpointOverride string, logEndpointOverride string, batch *Batch, collectTraceID bool, clientTimeout time.Duration) *Client {
 	httpClient := &http.Client{
-		Timeout: 500 * time.Millisecond,
+		Timeout: 800 * time.Millisecond,
 	}
 
 	// Create random seed for timeout to avoid instances created at the same time

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -116,7 +116,7 @@ func (c *Client) SendTelemetry(ctx context.Context, invokedFunctionARN string, t
 	}
 
 	transmitStart := time.Now()
-	successCount, sentBytes, _ := c.sendPayloads(compressedPayloads, builder)
+	successCount, sentBytes := c.sendPayloads(compressedPayloads, builder)
 	end := time.Now()
 	totalTime := end.Sub(start)
 	transmissionTime := end.Sub(transmitStart)
@@ -135,7 +135,7 @@ func (c *Client) SendTelemetry(ctx context.Context, invokedFunctionARN string, t
 
 type requestBuilder func(buffer *bytes.Buffer) (*http.Request, error)
 
-func (c *Client) sendPayloads(compressedPayloads []*bytes.Buffer, builder requestBuilder) (successCount int, sentBytes int, err error) {
+func (c *Client) sendPayloads(compressedPayloads []*bytes.Buffer, builder requestBuilder) (successCount int, sentBytes int) {
 	successCount = 0
 	sentBytes = 0
 	for _, p := range compressedPayloads {
@@ -168,7 +168,7 @@ func (c *Client) sendPayloads(compressedPayloads []*bytes.Buffer, builder reques
 		}
 	}
 
-	return successCount, sentBytes, nil
+	return successCount, sentBytes
 }
 
 type AttemptData struct {
@@ -282,7 +282,7 @@ func (c *Client) SendFunctionLogs(ctx context.Context, invokedFunctionARN string
 	}
 
 	transmitStart := time.Now()
-	successCount, sentBytes, err := c.sendPayloads(compressedPayloads, builder)
+	successCount, sentBytes := c.sendPayloads(compressedPayloads, builder)
 	end := time.Now()
 	totalTime := end.Sub(start)
 	transmissionTime := end.Sub(transmitStart)

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -158,7 +158,7 @@ func TestClientGetsHTTPError(t *testing.T) {
 	ctx := context.Background()
 	bytes := []byte("foobar")
 	err, successCount := client.SendTelemetry(ctx, "arn:aws:lambda:us-east-1:1234:function:newrelic-example-go", [][]byte{bytes})
-	assert.LessOrEqual(t, int(time.Since(startTime)), int(clientTestingTimeout)) // should exit as soon as a non-timeout error occurs without retrying
+	assert.Less(t, int(time.Since(startTime)), int(clientTestingTimeout)) // should exit as soon as a non-timeout error occurs without retrying
 	assert.NoError(t, err)
 	assert.Equal(t, 0, successCount)
 }

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	clientTestingTimeout = 300 * time.Millisecond
+	clientTestingTimeout = 400 * time.Millisecond
 )
 
 func TestClientSend(t *testing.T) {
@@ -111,7 +111,7 @@ func TestClientSendRetry(t *testing.T) {
 func TestClientReachesDataTimeout(t *testing.T) {
 	startTime := time.Now()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(300 * time.Millisecond)
 	}))
 
 	defer srv.Close()
@@ -123,7 +123,7 @@ func TestClientReachesDataTimeout(t *testing.T) {
 	ctx := context.Background()
 	bytes := []byte("foobar")
 	err, successCount := client.SendTelemetry(ctx, "arn:aws:lambda:us-east-1:1234:function:newrelic-example-go", [][]byte{bytes})
-	assert.LessOrEqual(t, int(time.Since(startTime)), int(clientTestingTimeout+10*time.Millisecond))
+	assert.LessOrEqual(t, int(time.Since(startTime)), int(clientTestingTimeout+250*time.Millisecond))
 	assert.NoError(t, err)
 	assert.Equal(t, 0, successCount)
 }

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	clientTestingTimeout = 400 * time.Millisecond
+	clientTestingTimeout = 800 * time.Millisecond
 )
 
 func TestClientSend(t *testing.T) {
@@ -111,7 +111,7 @@ func TestClientSendRetry(t *testing.T) {
 func TestClientReachesDataTimeout(t *testing.T) {
 	startTime := time.Now()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(300 * time.Millisecond)
+		time.Sleep(400 * time.Millisecond)
 	}))
 
 	defer srv.Close()


### PR DESCRIPTION
Users can now adjust how long the extension will attempt to retry
sending a data payload to New Relic using the environment variable
NEW_RELIC_DATA_COLLECTION_TIMEOUT. This gives customers more control
over the expected runtime of their application. Note that the extension may need to send more than one payload. The value of this timeout can be any
valid golang duration string. Some examples include 10s = 10 seconds;
500ms = 500 milliseconds; 1m = 1 minute. See
https://pkg.go.dev/maze.io/x/duration#ParseDuration for more info.

10s is the default.