### PR TITLE
Update Release Key to Read Write Key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,9 @@ jobs:
     docker:
       - image: cimg/go:1.19
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "e4:52:f3:6f:48:5f:ad:5b:bf:c1:d1:ed:14:20:a0:33"
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -102,6 +105,9 @@ jobs:
     docker:
       - image: cimg/go:1.19
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "e4:52:f3:6f:48:5f:ad:5b:bf:c1:d1:ed:14:20:a0:33"
       - attach_workspace:
           at: /tmp/workspace
       - run:


### PR DESCRIPTION
Allows Circle CI to publish releases to GitHub directly