### PR TITLE
extend HTTP timeout to 2.4s 

### DIFF
--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -41,7 +41,7 @@ type Client struct {
 // New creates a telemetry client with sensible defaults
 func New(functionName string, licenseKey string, telemetryEndpointOverride string, logEndpointOverride string, batch *Batch, collectTraceID bool, clientTimeout time.Duration) *Client {
 	httpClient := &http.Client{
-		Timeout: 2 * time.Second,
+		Timeout: 2400 * time.Millisecond,
 	}
 
 	// Create random seed for timeout to avoid instances created at the same time

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -41,7 +41,7 @@ type Client struct {
 // New creates a telemetry client with sensible defaults
 func New(functionName string, licenseKey string, telemetryEndpointOverride string, logEndpointOverride string, batch *Batch, collectTraceID bool, clientTimeout time.Duration) *Client {
 	httpClient := &http.Client{
-		Timeout: 800 * time.Millisecond,
+		Timeout: 2 * time.Second,
 	}
 
 	// Create random seed for timeout to avoid instances created at the same time


### PR DESCRIPTION
Due to latency issues in the EU region, we are extending the http timeout to 2 seconds, until the latency is back to normal. This may result in longer runtimes for applications with our layer in them, but will increase the chance data is sent to use successfully. 