### PR TITLE
Update deprecated API in python lambda handler example.

### DIFF
--- a/examples/sam/python/newrelic_example_python/app.py
+++ b/examples/sam/python/newrelic_example_python/app.py
@@ -13,7 +13,7 @@ def lambda_handler(event, context):
         "zip": "zap"
     })
     # This attribute gets added to the normal AwsLambdaInvocation event
-    agent.add_custom_parameter('customAttribute', 'customAttributeValue')
+    agent.add_custom_attribute('customAttribute', 'customAttributeValue')
 
     # As normal, anything you write to stdout ends up in CloudWatch
     print("Hello, world")


### PR DESCRIPTION
This PR updates Python example code to use `add_custom_attribute` instead of the deprecated `add_custom_parameter` API.

Related issue: #151 