### PR TITLE
Allow CJS Files 

### DIFF
--- a/checks/handler_check.go
+++ b/checks/handler_check.go
@@ -37,9 +37,10 @@ func (r runtimeConfig) check(h handlerConfigs) bool {
 	p := removePathMethodName(functionHandler)
 	if r.language == Node {
 		pJS := pathFormatter(p, "js")
+		cJS := pathFormatter(p, "cjs")
 		pMJS := pathFormatter(p, "mjs")
 
-		if util.PathExists(pJS) || util.PathExists(pMJS) {
+		if util.PathExists(pJS) || util.PathExists(pMJS) || util.PathExists(cJS) {
 			return true
 		}
 	} else {


### PR DESCRIPTION
 We use [SST](https://sst.dev/) with the `commonjs` esbuild configuration.  This builds our lambdas into `.cjs` files.  This change allows `cjs` files within the extension