### PR TITLE
fix: infinite recursive loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,6 +193,7 @@ func mainLoop(ctx context.Context, invocationClient *client.InvocationClient, ba
 			return eventCounter
 		default:
 			// Our call to next blocks. It is likely that the container is frozen immediately after we call NextEvent.
+			util.Debugln("mainLoop: blocking while awaiting next invocation event...")
 			event, err := invocationClient.NextEvent(ctx)
 
 			// We've thawed.
@@ -310,10 +311,12 @@ func pollLogServer(logServer *logserver.LogServer, batch *telemetry.Batch) {
 
 func shipHarvest(ctx context.Context, harvested []*telemetry.Invocation, telemetryClient *telemetry.Client) {
 	if len(harvested) > 0 {
+		util.Debugf("shipHarvest: harvesting agent telemetry")
 		telemetrySlice := make([][]byte, 0, 2*len(harvested))
 		for _, inv := range harvested {
 			telemetrySlice = append(telemetrySlice, inv.Telemetry...)
 		}
+		util.Debugf("shipHarveset: %d telemetry payloads harvested", len(telemetrySlice))
 
 		err, _ := telemetryClient.SendTelemetry(ctx, invokedFunctionARN, telemetrySlice)
 		if err != nil {

--- a/telemetry/batch_test.go
+++ b/telemetry/batch_test.go
@@ -24,6 +24,15 @@ var (
 	requestStart = time.Unix(1603821157, 0)
 )
 
+func generateNLengthTelemetryString(length int) string {
+	outStr := ""
+	for i := 0; i < length; i++ {
+		outStr += "a"
+	}
+
+	return outStr
+}
+
 func TestMissingInvocation(t *testing.T) {
 	batch := NewBatch(ripe, rot, false)
 
@@ -71,7 +80,7 @@ func TestWithInvocationRipeHarvest(t *testing.T) {
 	invocation := batch.AddTelemetry(testRequestId, bytes.NewBufferString(testTelemetry).Bytes())
 	assert.NotNil(t, invocation)
 
-	invocation2 := batch.AddTelemetry(testRequestId, bytes.NewBufferString(moreTestTelemetry).Bytes())
+	invocation2 := batch.AddTelemetry(testRequestId, []byte(testTelemetry))
 	assert.Equal(t, invocation, invocation2)
 
 	batch.AddTelemetry(testRequestId2, bytes.NewBufferString(testTelemetry).Bytes())
@@ -92,7 +101,7 @@ func TestWithInvocationAggressiveHarvest(t *testing.T) {
 	invocation := batch.AddTelemetry(testRequestId, bytes.NewBufferString(testTelemetry).Bytes())
 	assert.NotNil(t, invocation)
 
-	invocation2 := batch.AddTelemetry(testRequestId, bytes.NewBufferString(moreTestTelemetry).Bytes())
+	invocation2 := batch.AddTelemetry(testRequestId, bytes.NewBufferString(testTelemetry).Bytes())
 	assert.Equal(t, invocation, invocation2)
 
 	batch.AddTelemetry(testRequestId2, bytes.NewBufferString(testTelemetry).Bytes())
@@ -111,7 +120,7 @@ func TestBatch_Close(t *testing.T) {
 	invocation := batch.AddTelemetry(testRequestId, bytes.NewBufferString(testTelemetry).Bytes())
 	assert.NotNil(t, invocation)
 
-	invocation2 := batch.AddTelemetry(testRequestId, bytes.NewBufferString(moreTestTelemetry).Bytes())
+	invocation2 := batch.AddTelemetry(testRequestId, bytes.NewBufferString(testTelemetry).Bytes())
 	assert.Equal(t, invocation, invocation2)
 
 	batch.AddTelemetry(testRequestId2, bytes.NewBufferString(testTelemetry).Bytes())

--- a/telemetry/request.go
+++ b/telemetry/request.go
@@ -115,9 +115,8 @@ func CompressedPayloadsForLogEvents(logsEvents []LogsEvent, functionName string,
 	}
 
 	if compressed.Len() <= maxCompressedPayloadLen {
-		ret := []*bytes.Buffer{compressed}
-		return ret, nil
-	} else {
+		return []*bytes.Buffer{compressed}, nil
+	} else if len(logsEvents) > 1 {
 		// Payload is too large, split in half, recursively
 		split := len(logsEvents) / 2
 		leftRet, err := CompressedPayloadsForLogEvents(logsEvents[0:split], functionName, invokedFunctionARN)
@@ -131,6 +130,9 @@ func CompressedPayloadsForLogEvents(logsEvents []LogsEvent, functionName string,
 		}
 
 		return append(leftRet, rightRet...), nil
+	} else {
+		// when there is one event that is too large, we try to send it anyway. It will fail with a 413 error, but wont loop infinitely.
+		return []*bytes.Buffer{compressed}, nil
 	}
 }
 

--- a/telemetry/request_test.go
+++ b/telemetry/request_test.go
@@ -2,8 +2,9 @@ package telemetry
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSerialize_DetailedFunctionLog(t *testing.T) {


### PR DESCRIPTION
The telemetry/request.CompressedPayloadsForLogEvents() function has no base case for the case where the compressed payload is too large due to one single logsEvent being oversized. This causes an infinite recursive loop that will crash the extension. These changes patch that and cover this with a test case.