### PR TITLE
Add timeouts

### DIFF
--- a/checks/runtime_check.go
+++ b/checks/runtime_check.go
@@ -26,9 +26,9 @@ func init() {
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
-		Timeout: time.Second * 10,
+		Timeout: time.Second * 2,
 	}
-	githubClient = github.NewClient(&http.Client{Timeout: time.Second * 10})
+	githubClient = github.NewClient(&http.Client{Timeout: time.Second * 2})
 }
 
 func checkAndReturnRuntime() (runtimeConfig, error) {

--- a/checks/sanity_check.go
+++ b/checks/sanity_check.go
@@ -34,12 +34,12 @@ func sanityCheck(ctx context.Context, conf *config.Configuration, res *api.Regis
 	defer cancelSecret()
 	isSecretConfigured := credentials.IsSecretConfigured(ctxSecret, conf)
 
-	ctxSMParameter, cancelSMParameter := context.WithTimeout(ctx, timeout)
-	defer cancelSMParameter()
-	
+	ctxSSMParameter, cancelSSMParameter := context.WithTimeout(ctx, timeout)
+	defer cancelSSMParameter()
+
 	isSSMParameterConfigured := false
 	if conf.LicenseKeySSMParameterName != "" {
-		isSSMParameterConfigured = credentials.IsSSMParameterConfigured(ctxSMParameter, conf)
+		isSSMParameterConfigured = credentials.IsSSMParameterConfigured(ctxSSMParameter, conf)
 	}
 	
 

--- a/checks/sanity_check.go
+++ b/checks/sanity_check.go
@@ -3,6 +3,7 @@ package checks
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/newrelic/newrelic-lambda-extension/config"
 	"github.com/newrelic/newrelic-lambda-extension/credentials"
@@ -28,11 +29,17 @@ func sanityCheck(ctx context.Context, conf *config.Configuration, res *api.Regis
 	}
 
 	envKeyExists := util.EnvVarExists("NEW_RELIC_LICENSE_KEY")
-	isSecretConfigured := credentials.IsSecretConfigured(ctx, conf)
+	var timeout = 1 * time.Second
+	ctxSecret, cancelSecret := context.WithTimeout(ctx, timeout)
+	defer cancelSecret()
+	isSecretConfigured := credentials.IsSecretConfigured(ctxSecret, conf)
 
+	ctxSMParameter, cancelSMParameter := context.WithTimeout(ctx, timeout)
+	defer cancelSMParameter()
+	
 	isSSMParameterConfigured := false
 	if conf.LicenseKeySSMParameterName != "" {
-		isSSMParameterConfigured = credentials.IsSSMParameterConfigured(ctx, conf)
+		isSSMParameterConfigured = credentials.IsSSMParameterConfigured(ctxSMParameter, conf)
 	}
 	
 

--- a/checks/startup_check.go
+++ b/checks/startup_check.go
@@ -40,7 +40,7 @@ func RunChecks(ctx context.Context, conf *config.Configuration, reg *api.Registr
 func runCheck(ctx context.Context, conf *config.Configuration, reg *api.RegistrationResponse, r runtimeConfig, logSender LogSender, check checkFn) error {
 	err := check(ctx, conf, reg, r)
 	if err != nil {
-		errLog := fmt.Sprintf("Startup check failed: %v", err)
+		errLog := fmt.Sprintf("Startup check warning: %v", err)
 		util.Logln(errLog)
 
 		//Send a log line to NR as well

--- a/checks/startup_check_test.go
+++ b/checks/startup_check_test.go
@@ -65,7 +65,7 @@ func TestRunCheckErr(t *testing.T) {
 	assert.Equal(t, true, tested)
 	assert.NotNil(t, result)
 
-	assert.Equal(t, "Startup check failed: Failure Test", string(logSender.sent[0].Content))
+	assert.Equal(t, "Startup check warning: Failure Test", string(logSender.sent[0].Content))
 }
 
 func TestRunChecks(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 	}
 
 	// Attempt to find the license key for telemetry sending
-	var timeout = 5 * time.Second
+	var timeout = 1 * time.Second
 	ctxLicenseKey, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	licenseKey, err := credentials.GetNewRelicLicenseKey(ctxLicenseKey, conf)

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 	// Attempt to find the license key for telemetry sending
 	var timeout = 5 * time.Second
 	ctxLicenseKey, cancel := context.WithTimeout(ctx, timeout)
-    defer cancel()
+	defer cancel()
 	licenseKey, err := credentials.GetNewRelicLicenseKey(ctxLicenseKey, conf)
 	if err != nil {
 		util.Logln("Failed to retrieve New Relic license key", err)

--- a/main.go
+++ b/main.go
@@ -87,8 +87,8 @@ func main() {
 
 	// Attempt to find the license key for telemetry sending
 	var timeout = 1 * time.Second
-	ctxLicenseKey, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	ctxLicenseKey, cancelLicenseKey := context.WithTimeout(ctx, timeout)
+	defer cancelLicenseKey()
 	licenseKey, err := credentials.GetNewRelicLicenseKey(ctxLicenseKey, conf)
 	if err != nil {
 		util.Logln("Failed to retrieve New Relic license key", err)

--- a/main.go
+++ b/main.go
@@ -86,7 +86,10 @@ func main() {
 	}
 
 	// Attempt to find the license key for telemetry sending
-	licenseKey, err := credentials.GetNewRelicLicenseKey(ctx, conf)
+	var timeout = 5 * time.Second
+	ctxLicenseKey, cancel := context.WithTimeout(ctx, timeout)
+    defer cancel()
+	licenseKey, err := credentials.GetNewRelicLicenseKey(ctxLicenseKey, conf)
 	if err != nil {
 		util.Logln("Failed to retrieve New Relic license key", err)
 		// We fail open; telemetry will go to CloudWatch instead


### PR DESCRIPTION
Extension taking more than 2 minutes when in VPC without outbound traffic.

- Added timeout for calls to Secret & SSM Parameter Store
- Added context timeout for Sanity check calls for Secret and SSM Parameter Store
- Reduced timeout for github agent version check call to 2 seconds