### PR TITLE
NEW_RELIC_ENABLED  Env issue 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,8 @@ type Configuration struct {
 
 func ConfigurationFromEnvironment() *Configuration {
 	enabledStr, extensionEnabledOverride := os.LookupEnv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED")
+	nrEnabledStr, nrEnabledOverride := os.LookupEnv("NEW_RELIC_ENABLED")
+	nrEnabledRubyStr, nrEnabledRubyOverride := os.LookupEnv("NEW_RELIC_AGENT_ENABLED")
 	licenseKey, lkOverride := os.LookupEnv("NEW_RELIC_LICENSE_KEY")
 	licenseKeySecretId, lkSecretOverride := os.LookupEnv("NEW_RELIC_LICENSE_KEY_SECRET")
 	licenseKeySSMParameterName, lkSSMParameterOverride := os.LookupEnv("NEW_RELIC_LICENSE_KEY_SSM_PARAMETER_NAME")

--- a/config/config.go
+++ b/config/config.go
@@ -38,9 +38,9 @@ type Configuration struct {
 }
 
 func ConfigurationFromEnvironment() *Configuration {
-	enabledStr, extensionEnabledOverride := os.LookupEnv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED")
 	nrEnabledStr, nrEnabledOverride := os.LookupEnv("NEW_RELIC_ENABLED")
 	nrEnabledRubyStr, nrEnabledRubyOverride := os.LookupEnv("NEW_RELIC_AGENT_ENABLED")
+	enabledStr, extensionEnabledOverride := os.LookupEnv("NEW_RELIC_LAMBDA_EXTENSION_ENABLED")
 	licenseKey, lkOverride := os.LookupEnv("NEW_RELIC_LICENSE_KEY")
 	licenseKeySecretId, lkSecretOverride := os.LookupEnv("NEW_RELIC_LICENSE_KEY_SECRET")
 	licenseKeySSMParameterName, lkSSMParameterOverride := os.LookupEnv("NEW_RELIC_LICENSE_KEY_SSM_PARAMETER_NAME")
@@ -57,6 +57,12 @@ func ConfigurationFromEnvironment() *Configuration {
 	collectTraceIDStr, collectTraceIDOverride := os.LookupEnv("NEW_RELIC_COLLECT_TRACE_ID")
 
 	extensionEnabled := true
+	if nrEnabledOverride && strings.ToLower(nrEnabledStr) == "false" {
+		extensionEnabled = false
+	}
+	if nrEnabledRubyOverride && strings.ToLower(nrEnabledRubyStr) == "false" {
+		extensionEnabled = false
+	}
 	if extensionEnabledOverride && strings.ToLower(enabledStr) == "false" {
 		extensionEnabled = false
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -75,6 +75,22 @@ func TestConfigurationFromEnvironment(t *testing.T) {
 	assert.Equal(t, false, conf.LogsEnabled)
 }
 
+func TestConfigurationFromEnvironmentNREnabled(t *testing.T) {
+	os.Setenv("NEW_RELIC_ENABLED", "false")
+	defer os.Unsetenv("NEW_RELIC_ENABLED")
+
+	conf := ConfigurationFromEnvironment()
+	assert.Equal(t, conf.ExtensionEnabled, false)
+}
+
+func TestConfigurationFromEnvironmentNRAgentEnabled(t *testing.T) {
+	os.Setenv("NEW_RELIC_AGENT_ENABLED", "false")
+	defer os.Unsetenv("NEW_RELIC_AGENT_ENABLED")
+
+	conf := ConfigurationFromEnvironment()
+	assert.Equal(t, conf.ExtensionEnabled, false)
+}
+
 func TestConfigurationFromEnvironmentSecretId(t *testing.T) {
 	os.Setenv("NEW_RELIC_LICENSE_KEY_SECRET", "secretId")
 	defer os.Unsetenv("NEW_RELIC_LICENSE_KEY_SECRET")


### PR DESCRIPTION
- Solves [github issue](https://github.com/newrelic/newrelic-lambda-extension/issues/215) related to Extension not handling some environment variables
- Extension should be a no-op if NEW_RELIC_ENABLED=`false` or NEW_RELIC_AGENT_ENABLED=`false`