### PR TITLE
update NEW_RELIC_ENABLED to Env bool 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,8 +57,11 @@ func ConfigurationFromEnvironment() *Configuration {
 	collectTraceIDStr, collectTraceIDOverride := os.LookupEnv("NEW_RELIC_COLLECT_TRACE_ID")
 
 	extensionEnabled := true
-	if nrEnabledOverride && strings.ToLower(nrEnabledStr) == "false" {
-		extensionEnabled = false
+	if nrEnabledOverride {
+		b, err := strconv.ParseBool(nrEnabledStr)
+		if err == nil && !b {
+			extensionEnabled = false
+		}
 	}
 	if nrEnabledRubyOverride && strings.ToLower(nrEnabledRubyStr) == "false" {
 		extensionEnabled = false

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -83,6 +83,14 @@ func TestConfigurationFromEnvironmentNREnabled(t *testing.T) {
 	assert.Equal(t, conf.ExtensionEnabled, false)
 }
 
+func TestConfigurationFromEnvironmentNREnabledBool(t *testing.T) {
+	os.Setenv("NEW_RELIC_ENABLED", "0")
+	defer os.Unsetenv("NEW_RELIC_ENABLED")
+
+	conf := ConfigurationFromEnvironment()
+	assert.Equal(t, conf.ExtensionEnabled, false)
+}
+
 func TestConfigurationFromEnvironmentNRAgentEnabled(t *testing.T) {
 	os.Setenv("NEW_RELIC_AGENT_ENABLED", "false")
 	defer os.Unsetenv("NEW_RELIC_AGENT_ENABLED")


### PR DESCRIPTION
- Go Agent uses [ParseBool](https://github.com/newrelic/go-agent/blob/6c84bcfba282b0c2984582cff8bca8eb9a3e1ee0/v3/newrelic/config_options.go#L413) for some env variables.
- updating `NEW_RELIC_ENABLED`  as customer would like to use similar feature in lambda environment
- [Github issue link](https://github.com/newrelic/newrelic-lambda-extension/issues/215)