### PR TITLE
add checks if AWS arn is used for license key

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 	}
 
 	// Attempt to find the license key for telemetry sending
-	var timeout = 1 * time.Second
+	var timeout = 5 * time.Second
 	ctxLicenseKey, cancelLicenseKey := context.WithTimeout(ctx, timeout)
 	defer cancelLicenseKey()
 	licenseKey, err := credentials.GetNewRelicLicenseKey(ctxLicenseKey, conf)


### PR DESCRIPTION
add checks if AWS arn is used for license key, so that secrets manager can be used cross-region