### PR TITLE
Send Extension log events

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The New Relic Lambda Extension can also send your function's logs to New Relic. 
 | Environment variable | Default value | Options | Description |
 |--------|-----------|-------------|-------------|
 | `NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS` | `false` | `true` , `false` | Send function logs to New Relic. |
+| `NEW_RELIC_EXTENSION_SEND_EXTENSION_LOGS` | `false` | `true` , `false` | Send extension logs in addition to the function logs to New Relic. |
 | `NEW_RELIC_EXTENSION_LOGS_ENABLED` | `true` | `true` , `false` | Enable or disable `[NR_EXT]` log lines |
 | `NR_TAGS` |  | | Specify tags to be added to all log events. **Optional**. Each tag is composed of a colon-delimited key and value. Multiple key-value pairs are semicolon-delimited; for example, env:prod;team:myTeam. |
 | `NR_ENV_DELIMITER` | | | Some users in UTF-8 environments might face difficulty in defining strings of `NR_TAGS` delimited by the semicolon `;` character. Use `NR_ENV_DELIMITER`, to set custom delimiter for `NR_TAGS`. |

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type Configuration struct {
 	IgnoreExtensionChecks      map[string]bool
 	LogsEnabled                bool
 	SendFunctionLogs           bool
+	SendExtensionLogs		   bool
 	CollectTraceID             bool
 	RipeMillis                 uint32
 	RotMillis                  uint32
@@ -87,6 +88,7 @@ func ConfigurationFromEnvironment() *Configuration {
 	logLevelStr, logLevelOverride := os.LookupEnv("NEW_RELIC_EXTENSION_LOG_LEVEL")
 	logsEnabledStr, logsEnabledOverride := os.LookupEnv("NEW_RELIC_EXTENSION_LOGS_ENABLED")
 	sendFunctionLogsStr, sendFunctionLogsOverride := os.LookupEnv("NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS")
+	sendExtensionLogsStr, sendExtensionLogsOverride := os.LookupEnv("NEW_RELIC_EXTENSION_SEND_EXTENSION_LOGS")
 	logServerHostStr, logServerHostOverride := os.LookupEnv("NEW_RELIC_LOG_SERVER_HOST")
 	collectTraceIDStr, collectTraceIDOverride := os.LookupEnv("NEW_RELIC_COLLECT_TRACE_ID")
 
@@ -179,6 +181,10 @@ func ConfigurationFromEnvironment() *Configuration {
 
 	if sendFunctionLogsOverride && sendFunctionLogsStr == "true" {
 		ret.SendFunctionLogs = true
+	}
+
+	if sendExtensionLogsOverride && strings.ToLower(sendExtensionLogsStr) == "true" {
+		ret.SendExtensionLogs = true
 	}
 
 	if collectTraceIDOverride && collectTraceIDStr == "true" {

--- a/lambda/logserver/logserver.go
+++ b/lambda/logserver/logserver.go
@@ -124,6 +124,15 @@ func (ls *LogServer) handler(res http.ResponseWriter, req *http.Request) {
 
 	for _, event := range logEvents {
 		switch event.Type {
+		case "extension":
+			record := event.Record.(string)
+			ls.lastRequestIdLock.Lock()
+			functionLogs = append(functionLogs, LogLine{
+				Time:      event.Time,
+				RequestID: ls.lastRequestId,
+				Content:   []byte(record),
+			})
+			ls.lastRequestIdLock.Unlock()
 		case "platform.start":
 			ls.lastRequestIdLock.Lock()
 			switch event.Record.(type) {

--- a/lambda/logserver/logserver.go
+++ b/lambda/logserver/logserver.go
@@ -124,15 +124,6 @@ func (ls *LogServer) handler(res http.ResponseWriter, req *http.Request) {
 
 	for _, event := range logEvents {
 		switch event.Type {
-		case "extension":
-			record := event.Record.(string)
-			ls.lastRequestIdLock.Lock()
-			functionLogs = append(functionLogs, LogLine{
-				Time:      event.Time,
-				RequestID: ls.lastRequestId,
-				Content:   []byte(record),
-			})
-			ls.lastRequestIdLock.Unlock()
 		case "platform.start":
 			ls.lastRequestIdLock.Lock()
 			switch event.Record.(type) {
@@ -181,7 +172,7 @@ func (ls *LogServer) handler(res http.ResponseWriter, req *http.Request) {
 			ls.platformLogChan <- reportLine
 		case "platform.logsDropped":
 			util.Logf("Platform dropped logs: %v", event.Record)
-		case "function":
+		case "function", "extension":
 			record := event.Record.(string)
 			ls.lastRequestIdLock.Lock()
 			functionLogs = append(functionLogs, LogLine{

--- a/main.go
+++ b/main.go
@@ -114,6 +114,9 @@ func main() {
 	if conf.SendFunctionLogs {
 		eventTypes = append(eventTypes, api.Function)
 	}
+	if conf.SendExtensionLogs {
+		eventTypes = append(eventTypes, api.Extension)
+	}
 	subscriptionRequest := api.DefaultLogSubscription(eventTypes, logServer.Port())
 	err = invocationClient.LogRegister(ctx, subscriptionRequest)
 	if err != nil {


### PR DESCRIPTION
- Subscribe to `Extension` log EventType in `subscriptionRequest` to be send to Logs API to receive Extension log events
- Create env var `NEW_RELIC_EXTENSION_SEND_EXTENSION_LOGS` to enable sending Extension log events to New Relic
- Send the Extension logs to FunctionLogs channel which receives all logs and sends it as log Payload to New Relic Log endpoint
- Update Readme 