### PR TITLE
Record platform fault which triggers shutdown

### DIFF
--- a/lambda/logserver/logserver.go
+++ b/lambda/logserver/logserver.go
@@ -172,7 +172,7 @@ func (ls *LogServer) handler(res http.ResponseWriter, req *http.Request) {
 			ls.platformLogChan <- reportLine
 		case "platform.logsDropped":
 			util.Logf("Platform dropped logs: %v", event.Record)
-		case "function", "extension":
+		case "function", "extension", "platform.fault":
 			record := event.Record.(string)
 			ls.lastRequestIdLock.Lock()
 			functionLogs = append(functionLogs, LogLine{

--- a/main.go
+++ b/main.go
@@ -251,7 +251,7 @@ func mainLoop(ctx context.Context, invocationClient *client.InvocationClient, ba
 					batch.AddTelemetry(lastRequestId, []byte(timeoutMessage))
 				} else if event.ShutdownReason == api.Failure && lastRequestId != "" {
 					// Synthesize a generic platform error. Probably an OOM, though it could be any runtime crash.
-					errorMessage := fmt.Sprintf("RequestId: %s A platform error caused a shutdown", lastRequestId)
+					errorMessage := fmt.Sprintf("RequestId: %s AWS Lambda platform fault caused a shutdown", lastRequestId)
 					batch.AddTelemetry(lastRequestId, []byte(errorMessage))
 				}
 


### PR DESCRIPTION
- Logs API provides event type = `platform.fault` as mentioned [here](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-logs-api.html#:~:text=end%2C%20and-,platform.fault,-.)
- Shutdown event is sent to Extension for the reason mentioned [here](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html#runtimes-extensions-api-failure)