### PR TITLE
Modify workflow to upload Codecov report

### DIFF
--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -47,7 +47,7 @@ jobs:
           go-version: '1.23'
           cache: true
       - name: Generate coverage report
-        run: make coverage
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v5.3.1
         with: 

--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -47,7 +47,7 @@ jobs:
           go-version: '1.23'
           cache: true
       - name: Generate coverage report
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+        run: go test -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v5.3.1
         with: 

--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -53,3 +53,4 @@ jobs:
         with: 
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true  
+          files: ./coverage.txt

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "github.com/newrelic/newrelic-lambda-extension/examples/sam/go"
+  - "examples/sam/go"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "github.com/newrelic/newrelic-lambda-extension/examples/sam/go"

--- a/coverage.sh
+++ b/coverage.sh
@@ -2,6 +2,7 @@
 
 set -e
 echo "" > coverage.txt
+
 go test -coverprofile=profile.out -covermode=atomic main.go
 if [ -f profile.out ]; then
     cat profile.out >> coverage.txt

--- a/coverage.sh
+++ b/coverage.sh
@@ -2,8 +2,6 @@
 
 set -e
 echo "" > coverage.txt
-pwd
-ls
 go test -coverprofile=profile.out -covermode=atomic main.go
 if [ -f profile.out ]; then
     cat profile.out >> coverage.txt

--- a/coverage.sh
+++ b/coverage.sh
@@ -2,7 +2,8 @@
 
 set -e
 echo "" > coverage.txt
-
+pwd
+ls
 go test -coverprofile=profile.out -covermode=atomic main.go
 if [ -f profile.out ]; then
     cat profile.out >> coverage.txt


### PR DESCRIPTION
- Updated GitHub actions workflow to run Codecov coverage as a task
- We can see that after ignoring examples folder the codecov coverage improved from ` 78.46%` to `79.71%`