### PR TITLE
add vendor utilization data for connect request

### DIFF
--- a/apm/collector.go
+++ b/apm/collector.go
@@ -48,6 +48,7 @@ type RpmCmd struct {
 	Data              []byte
 	RequestHeadersMap map[string]string
 	MaxPayloadSize    int
+	metaData          map[string]interface{}
 }
 
 type RpmControls struct {
@@ -258,9 +259,14 @@ func ProcessData(data []interface{}, runId string) []interface{} {
 	return data
 }
 
-func NewAPMClient(conf *config.Configuration, FunctionName string) (RpmCmd, *RpmControls, error) {
+func NewAPMClient(conf *config.Configuration, awsFunctionName string, awsAccountId string, awsFunctionVersion string) (RpmCmd, *RpmControls, error) {
 	cmd := RpmCmd{
 		Collector: conf.NewRelicHost,
+		metaData: map[string]interface{}{
+			"AWSFunctionName": awsFunctionName,
+			"AWSAccountId": awsAccountId,
+			"AWSFunctionVersion": awsFunctionVersion,
+		},
 	}
 
 	cs := RpmControls{
@@ -274,7 +280,7 @@ func NewAPMClient(conf *config.Configuration, FunctionName string) (RpmCmd, *Rpm
 				return w
 			},
 		},
-		FunctionName: FunctionName,
+		FunctionName: awsFunctionName,
 	}
 	if conf.PreconnectEnabled {
 		// Perform Preconnect before sending cmd

--- a/lambda/extension/api/api.go
+++ b/lambda/extension/api/api.go
@@ -29,6 +29,7 @@ const (
 	LambdaHostPortEnvVar = "AWS_LAMBDA_RUNTIME_API"
 
 	ExtensionNameHeader      = "Lambda-Extension-Name"
+	ExtensionFeatureHeader   = "Lambda-Extension-Accept-Feature"
 	ExtensionIdHeader        = "Lambda-Extension-Identifier"
 	ExtensionErrorTypeHeader = "Lambda-Extension-Function-Error-Type"
 

--- a/lambda/extension/client/client.go
+++ b/lambda/extension/client/client.go
@@ -33,6 +33,7 @@ type RegistrationClient struct {
 	version       string
 	baseUrl       string
 	httpClient    http.Client
+	extensionFeature string
 }
 
 // Constructs a new RegistrationClient. This is the entry point.
@@ -49,6 +50,7 @@ func New(httpClient http.Client) *RegistrationClient {
 		version:       api.Version,
 		baseUrl:       os.Getenv(api.LambdaHostPortEnvVar),
 		httpClient:    httpClient,
+		extensionFeature: "accountId",
 	}
 }
 
@@ -77,6 +79,7 @@ func (rc *RegistrationClient) Register(ctx context.Context, registrationRequest 
 	}
 
 	req.Header.Set(api.ExtensionNameHeader, rc.extensionName)
+	req.Header.Set(api.ExtensionFeatureHeader, rc.extensionFeature)
 
 	res, err := rc.httpClient.Do(req)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func mainLoop(ctx context.Context, invocationClient *client.InvocationClient, ba
 			event, err := invocationClient.NextEvent(ctx)
 			if conf.APMLambdaMode {
 				apm.Once.Do(func() {
-					apmCmd, apmControls, err = apm.NewAPMClient(conf, LambdaFunctionName)
+					apmCmd, apmControls, err = apm.NewAPMClient(conf, LambdaFunctionName, LambdaAccountId, LambdaFunctionVersion)
 					if err != nil {
 						util.Logln("mainLoop: failed to initialize APM client:", err)
 					}


### PR DESCRIPTION
Add fields such as `aws.arn`, `aws.region`, `aws.accountId`, and  `aws.functionName` under `utilization` for connect call