### PR TITLE
update ubuntu runner

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build-release-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
           gh release upload "$TAG" "$file"
   
   build-release-arm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
 
 
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: build-test
     steps:
       - name: Checkout code


### PR DESCRIPTION
- While testing release of test Extension, received error message - `This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15`
- We can see that Ubuntu 20.04 is deprecated in the [GitHub runner-images](https://github.com/actions/runner-images?tab=readme-ov-file#available-images)