### PR TITLE
chore: updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ to install the managed secret, and then add the permission for the secret to you
     newrelic-lambda integrations install \
         --nr-account-id <account id> \
         --nr-api-key <api key> \
-        --linked-account-name <linked account name> \
-        --enable-license-key-secret
+        --linked-account-name <linked account name> 
 
 Each of the example functions in the `examples` directory has the appropriate license key secret permission. 
 


### PR DESCRIPTION
## Ticket: [NR-404207](https://new-relic.atlassian.net/browse/NR-404207)
### Details:
- According to the ticket, we noticed that `--enable-license-key-secret` is set to true by default, so it's not required to specify it during integrations installation.


[NR-404207]: https://new-relic.atlassian.net/browse/NR-404207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ