### PR TITLE
Add godebug to resolve AWS Firewall issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/newrelic/newrelic-lambda-extension
 
 go 1.23.8
 
+// Go experimental release X25519Kyber768Draft00 is causing issue with AWS Network Firewall
+godebug tlskyber=0
+
 require (
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/google/go-github/v68 v68.0.0

--- a/util/extension.go
+++ b/util/extension.go
@@ -2,6 +2,6 @@ package util
 
 const (
 	Name    = "newrelic-lambda-extension"
-	Version = "2.3.21"
+	Version = "2.3.22"
 	Id      = Name + ":" + Version
 )


### PR DESCRIPTION

- Add `godebug` to resolve AWS Firewall issue due to go experimental key exchange mechanism X25519Kyber768Draft00
- Resolves GitHub issue #313 