### PR TITLE
Add proxy host for extension

### DIFF
--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -50,6 +50,9 @@ type Client struct {
 func New(functionName string, licenseKey string, telemetryEndpointOverride string, logEndpointOverride string, batch *Batch, collectTraceID bool, clientTimeout time.Duration) *Client {
 	httpClient := &http.Client{
 		Timeout: httpClientTimeout,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
 	}
 
 	// Create random seed for timeout to avoid instances created at the same time

--- a/util/extension.go
+++ b/util/extension.go
@@ -2,6 +2,6 @@ package util
 
 const (
 	Name    = "newrelic-lambda-extension"
-	Version = "2.3.23"
+	Version = "2.3.24"
 	Id      = Name + ":" + Version
 )


### PR DESCRIPTION
- Add proxy host which can be used by extension https requests
- This implementation is similar to how the New Relic Go agent uses [proxy](https://github.com/newrelic/go-agent/blob/master/v3/newrelic/transport_1_12.go#L20)
