### PR TITLE
add tags to APM Mode

### DIFF
--- a/apm/connect.go
+++ b/apm/connect.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/newrelic/newrelic-lambda-extension/checks"
 	"github.com/newrelic/newrelic-lambda-extension/config"
+	"github.com/newrelic/newrelic-lambda-extension/telemetry"
 	"github.com/newrelic/newrelic-lambda-extension/util"
 )
 
@@ -131,6 +132,11 @@ func getLabels(cmd RpmCmd) []Label {
 	labels := []Label{
 		{LabelType: "aws.arn", LabelValue: lambdaARN},
 		{LabelType: "isLambdaFunction", LabelValue: "true"},
+	}
+	awsTags := map[string]interface{}{}
+	telemetry.GetNewRelicTags(awsTags)
+	for k, v := range awsTags {
+		labels = append(labels, Label{LabelType: k, LabelValue: fmt.Sprintf("%v", v)})
 	}
 	return labels
 }

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -286,7 +286,7 @@ func (c *Client) SendFunctionLogs(ctx context.Context, invokedFunctionARN string
 }
 
 // getNewRelicTags adds tags to the logs if NR_TAGS has values
-func getNewRelicTags(common map[string]interface{}) {
+func GetNewRelicTags(common map[string]interface{}) {
     nrTagsStr := os.Getenv("NR_TAGS")
     nrDelimiter := os.Getenv("NR_ENV_DELIMITER")
     if nrDelimiter == "" {
@@ -321,7 +321,7 @@ func (c *Client) buildLogPayloads(ctx context.Context, invokedFunctionARN string
 		common["entity.type"] = "APM"
 		common["entity.name"] = c.functionName
 	}
-	getNewRelicTags(common)
+	GetNewRelicTags(common)
 
 	logMessages := make([]FunctionLogMessage, 0, len(lines))
 	for _, l := range lines {

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -564,7 +564,7 @@ func TestGetNewRelicTags(t *testing.T) {
 				common[k] = v
 			}
 
-			getNewRelicTags(common)
+			GetNewRelicTags(common)
 
 			for k, v := range tt.expected {
 				if common[k] != v {


### PR DESCRIPTION
add tags to APM Mode using the existing feature which is used for Logs `NR_TAGS` and  `NR_ENV_DELIMITER`