### PR TITLE
feat: Add GitHub Actions workflow for publishing Lambda layers

### DIFF
--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -1,0 +1,61 @@
+name: Publish Lambda Layer
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-layers:
+    runs-on: ubuntu-latest
+    outputs:
+      x86_arn: ${{ steps.publish.outputs.x86_arn }}
+      arm_arn: ${{ steps.publish.outputs.arm_arn }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Install AWS CLI
+        run: pip install -U awscli
+
+      - name: Publish Extension Layer
+        id: publish
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: ./release-testing/publish-layer.sh
+
+  invoke-lambda:
+    needs: publish-layers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke for Cold Start
+        env:
+          API_URL: ${{ secrets.API_GATEWAY_URL }}
+          API_KEY: ${{ secrets.API_GATEWAY_KEY }}
+        run: |
+          echo "Invoking Lambda with x86 ARN: ${{ needs.publish-layers.outputs.x86_arn }}"
+          echo "Invoking Lambda with ARM ARN: ${{ needs.publish-layers.outputs.arm_arn }}"
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: $API_KEY" \
+            --data '{ "x86_layer_arn": "${{ needs.publish-layers.outputs.x86_arn }}", "arm_layer_arn": "${{ needs.publish-layers.outputs.arm_arn }}", "execution_phase": "cold" }' \
+            $API_URL
+
+      - name: Wait for 8 minutes
+        run: sleep 480
+
+      - name: Invoke for Warm Start
+        env:
+          API_URL: ${{ secrets.API_GATEWAY_URL }}
+          API_KEY: ${{ secrets.API_GATEWAY_KEY }}
+        run: |
+          echo "Invoking Lambda with x86 ARN: ${{ needs.publish-layers.outputs.x86_arn }}"
+          echo "Invoking Lambda with ARM ARN: ${{ needs.publish-layers.outputs.arm_arn }}"
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: $API_KEY" \
+            --data '{ "x86_layer_arn": "${{ needs.publish-layers.outputs.x86_arn }}", "arm_layer_arn": "${{ needs.publish-layers.outputs.arm_arn }}", "execution_phase": "warm" }' \
+            $API_URL

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ dist-arm64: clean
 	touch preview-extensions-ggqizro707
 
 zip-x86_64: dist-x86_64
-	zip -r /tmp/newrelic-lambda-extension.x86_64.zip preview-extensions-ggqizro707 extensions
+	zip -qr /tmp/newrelic-lambda-extension.x86_64.zip preview-extensions-ggqizro707 extensions
 
 zip-arm64: dist-arm64
-	zip -r /tmp/newrelic-lambda-extension.arm64.zip preview-extensions-ggqizro707 extensions
+	zip -qr /tmp/newrelic-lambda-extension.arm64.zip preview-extensions-ggqizro707 extensions
 
 test:
 	@echo "Normal tests"

--- a/release-testing/publish-layer.sh
+++ b/release-testing/publish-layer.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+EXTENSION_VERSION="2.3.23"
+PRIMARY_REGION="us-west-1"
+REGIONS=(
+  us-west-1
+)
+
+hash_file() {
+  if command -v md5sum &>/dev/null; then
+    md5sum "$1" | awk '{ print $1 }'
+  else
+    md5 -q "$1"
+  fi
+}
+
+layer_name_str() {
+  local arch=$1
+  local arch_part=""
+  if [[ "$arch" == "arm64" ]]; then
+    arch_part="ARM64"
+  fi
+  echo "NewRelicLambdaExtension${arch_part}"
+}
+
+publish_layer() {
+  local layer_archive=$1
+  local region=$2
+  local arch=$3
+
+  local layer_name
+  layer_name=$(layer_name_str "$arch")
+  local hash
+  hash=$(hash_file "$layer_archive")
+  local bucket_name="nr-extension-test-layers-${region}"
+  local s3_key="nr-extension/${hash}.${arch}.zip"
+  local compat_list=("provided" "provided.al2" "provided.al2023")
+  local description="New Relic Layer for provided (${arch}) with New Relic Extension v${EXTENSION_VERSION}"
+
+  echo "Uploading ${layer_archive} to s3://${bucket_name}/${s3_key}" >&2
+  aws --region "$region" s3 cp "$layer_archive" "s3://${bucket_name}/${s3_key}" --no-progress >/dev/null
+  if [ $? -ne 0 ]; then
+    echo "ERROR: AWS S3 upload failed for ${layer_archive} in region ${region}." >&2
+    return 1
+  fi
+
+  echo "Publishing layer to ${region}" >&2
+  local layer_arn
+  layer_arn=$(
+    aws lambda publish-layer-version \
+      --layer-name "${layer_name}" \
+      --content "S3Bucket=${bucket_name},S3Key=${s3_key}" \
+      --description "${description}" \
+      --license-info "Apache-2.0" \
+      --compatible-architectures "$arch" \
+      --compatible-runtimes "${compat_list[@]}" \
+      --region "$region" \
+      --output text \
+      --query LayerVersionArn
+  )
+
+  if [ $? -ne 0 ] || [ -z "$layer_arn" ]; then
+    echo "ERROR: Failed to publish Lambda layer for ${arch} in ${region}." >&2
+    return 1
+  fi
+
+  local layer_version
+  layer_version=$(echo "$layer_arn" | awk -F':' '{print $NF}')
+  echo "Published version ${layer_version} to ${region}" >&2
+
+  aws lambda add-layer-version-permission \
+    --layer-name "${layer_name}" \
+    --version-number "$layer_version" \
+    --statement-id public \
+    --action lambda:GetLayerVersion \
+    --principal "*" \
+    --region "$region" >/dev/null
+
+  echo "$layer_arn"
+}
+
+build_and_publish_for_arch() {
+  local arch=$1
+  local zip_file="/tmp/newrelic-lambda-extension.${arch}.zip"
+  local make_target="zip-${arch}"
+  local primary_arn=""
+
+  echo "Processing architecture: ${arch}" >&2
+  
+  echo "Building layer zip file with 'make ${make_target}'..." >&2
+  make --silent "${make_target}"
+
+  echo "Publishing ${arch} layer to all regions from ${zip_file}..." >&2
+  for region in "${REGIONS[@]}"; do
+    local arn
+    arn=$(publish_layer "$zip_file" "$region" "$arch")
+    if [[ "$region" == "$PRIMARY_REGION" ]]; then
+      primary_arn=$arn
+    fi
+  done
+
+  echo "$primary_arn"
+}
+
+echo "Starting layer publication process..." >&2
+
+x86_arn=$(build_and_publish_for_arch "x86_64")
+if [ -z "$x86_arn" ]; then
+  echo "ERROR: Could not get ARN for primary region ${PRIMARY_REGION} for x86." >&2
+  exit 1
+fi
+echo "x86_arn=${x86_arn}" >>"$GITHUB_OUTPUT"
+echo "Successfully set output for x86_arn" >&2
+
+arm_arn=$(build_and_publish_for_arch "arm64")
+if [ -z "$arm_arn" ]; then
+  echo "ERROR: Could not get ARN for primary region ${PRIMARY_REGION} for arm64." >&2
+  exit 1
+fi
+echo "arm_arn=${arm_arn}" >>"$GITHUB_OUTPUT"
+echo "Successfully set output for arm_arn" >&2
+
+echo "All layers published successfully." >&2


### PR DESCRIPTION
## What is the goal of this PR?
Currently, testing the Lambda extension requires a manual process of building, publishing to AWS, and invoking a Lambda. This is slow, error-prone, and not automated.

This PR introduces a new GitHub Actions workflow to automate the entire end-to-end integration testing process. This will allow developers to quickly and reliably test changes to the extension with a single click before a release. Along with cold start and warm start measurements which can be seen from newrelic dashboard.

## What has been changed?
This PR introduces the following changes:

**New GitHub Actions Workflow**: Adds a new workflow at .github/workflows/release-testing.yml. This workflow is manually triggered and contains two jobs:

**publish-layers**: Compiles the Go extension using the Makefile, creates x86_64 and arm64 Lambda Layers, publishes them to AWS, and outputs their ARNs.

**invoke-lambda**: Receives the new layer ARNs and invokes a test Lambda via API Gateway to perform cold and warm start tests.

## How can this be tested?
To test this new workflow:

Ensure the following secrets are configured in the repository's settings under Settings > Secrets and variables > Actions:

AWS_ACCESS_KEY_ID

AWS_SECRET_ACCESS_KEY

API_GATEWAY_URL

API_GATEWAY_KEY

Go to the Actions tab in the GitHub repository.

Select the "Lambda Extension Integration Test" workflow from the sidebar.

Click the "Run workflow" button and run it on this branch.

Observe the workflow run for a successful completion of both the publish-layers and invoke-lambda jobs.