### PR TITLE
feat: Update backoff duration for NEW_RELIC_HOST

### DIFF
--- a/apm/internal_app.go
+++ b/apm/internal_app.go
@@ -151,7 +151,7 @@ func (app *InternalAPMApp) connectRoutine() {
 		}
 
 		backoff := getConnectBackoffTime(attempts)
-		time.Sleep(time.Duration(backoff) * time.Second)
+		time.Sleep(backoff)
 		attempts++
 	}
 
@@ -159,8 +159,12 @@ func (app *InternalAPMApp) connectRoutine() {
 	util.Fatal(fmt.Errorf("failed to connect to collector after %d attempts", maxAttempts))
 }
 
-func getConnectBackoffTime(attempt int) int {
-	connectBackoffTimes := [...]int{15, 15, 30}
+func getConnectBackoffTime(attempt int) time.Duration {
+	connectBackoffTimes := [...]time.Duration{
+		200 * time.Millisecond,
+		500 * time.Millisecond,
+		900 * time.Millisecond,
+	}
 	l := len(connectBackoffTimes)
 	if (attempt < 0) || (attempt >= l) {
 		return connectBackoffTimes[l-1]

--- a/apm/internal_app_test.go
+++ b/apm/internal_app_test.go
@@ -17,4 +17,27 @@ func TestGetConnectBackoffTime(t *testing.T) {
 			t.Errorf("Invalid connect backoff for attempt #%d: got %v, want %v", k, b, v)
 		}
 	}
+	b := getConnectBackoffTime(10)
+	if b != 900*time.Millisecond {
+		t.Errorf("Out-of-bounds attempt should return last backoff, got %v", b)
+	}
+}
+func TestSetState(t *testing.T) {
+	app := &InternalAPMApp{}
+	run := &appRun{}
+	err := error(nil)
+	app.setState(run, err)
+	if app.Run != run {
+		t.Error("Run not set correctly")
+	}
+	if app.err != err {
+		t.Error("Error not set correctly")
+	}
+}
+
+func TestHarvestStruct(t *testing.T) {
+	h := &harvest{data: [][]byte{[]byte("test")}}
+	if len(h.data) != 1 {
+		t.Error("Expected harvest data length 1")
+	}
 }

--- a/apm/internal_app_test.go
+++ b/apm/internal_app_test.go
@@ -1,21 +1,20 @@
 package apm
 
 import (
-	"fmt"
 	"testing"
-
+	"time"
 )
 
-func TestConnectBackoff(t *testing.T) {
-	attempts := map[int]int{
-		0: 15,
-		1: 15,
-		2: 30,
+func TestGetConnectBackoffTime(t *testing.T) {
+	attempts := []time.Duration{
+		200 * time.Millisecond,
+		500 * time.Millisecond,
+		900 * time.Millisecond,
 	}
-
 	for k, v := range attempts {
-		if b := getConnectBackoffTime(k); b != v {
-			t.Error(fmt.Sprintf("Invalid connect backoff for attempt #%d:", k), v)
+		b := getConnectBackoffTime(k)
+		if b != v {
+			t.Errorf("Invalid connect backoff for attempt #%d: got %v, want %v", k, b, v)
 		}
 	}
 }


### PR DESCRIPTION
## Ticket: [NR-428800](https://new-relic.atlassian.net/browse/NR-428800)
## Details: 
The `NEW_RELIC_HOST` backoff times were updated for 3 retries to approximately: 200, 500, 900 ms.

## Output - Log:
```
[NR_EXT] Retry 1 took 207.985511ms (including backoff of 200ms)
[NR_EXT] Retry 2 took 728.646959ms (including backoff of 500ms)
[NR_EXT] Retry 3 took 1.649241537s (including backoff of 900ms)
```


[NR-428800]: https://new-relic.atlassian.net/browse/NR-428800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ