### PR TITLE
NR-560730 Add Japan (jp) region endpoint support

### DIFF
--- a/apm/collector_test.go
+++ b/apm/collector_test.go
@@ -76,6 +76,18 @@ func TestPreconnectHost_RegionLicense(t *testing.T) {
 	}
 }
 
+func TestPreconnectHost_RegionLicenseJP(t *testing.T) {
+	conf := &config.Configuration{
+		NewRelicHost: "",
+		LicenseKey:   "jp01xx000000000000000000000000000000NRAL",
+	}
+	got := preconnectHost(conf)
+	want := "collector.jp01.nr-data.net"
+	if got != want {
+		t.Errorf("preconnectHost() = %q, want %q", got, want)
+	}
+}
+
 func TestPreconnectHost_RegionLicense_NoMatch(t *testing.T) {
 	conf := &config.Configuration{
 		NewRelicHost: "",

--- a/apm/metric_api.go
+++ b/apm/metric_api.go
@@ -17,6 +17,7 @@ import (
 const (
 	MetricEndpointEU string = "https://metric-api.eu.newrelic.com/metric/v1"
 	MetricEndpointUS string = "https://metric-api.newrelic.com/metric/v1"
+	MetricEndpointJP string = "https://metric-api.jp.newrelic.com/metric/v1"
 )
 
 // Precompile regex patterns at package level for reusability
@@ -191,6 +192,10 @@ func getMetricEndpointURL(licenseKey string, metricEndpointOverride string) stri
 
 	if strings.HasPrefix(licenseKey, "eu") {
 		return MetricEndpointEU
+	}
+
+	if strings.HasPrefix(licenseKey, "jp") {
+		return MetricEndpointJP
 	}
 
 	return MetricEndpointUS

--- a/apm/metric_api_test.go
+++ b/apm/metric_api_test.go
@@ -310,6 +310,12 @@ func Test_getMetricEndpointURL(t *testing.T) {
 			want:       MetricEndpointUS,
 		},
 		{
+			name:       "JP license key, no override",
+			licenseKey: "jp01xx1234567890abcdef",
+			metricEndpointOverride: "",
+			want:       MetricEndpointJP,
+		},
+		{
 			name:       "Non-EU, non-US license key, no override",
 			licenseKey: "xx01xx1234567890abcdef",
 			metricEndpointOverride: "",

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -24,8 +24,10 @@ import (
 const (
 	InfraEndpointEU string = "https://cloud-collector.eu01.nr-data.net/aws/lambda/v1"
 	InfraEndpointUS string = "https://cloud-collector.newrelic.com/aws/lambda/v1"
+	InfraEndpointJP string = "https://cloud-collector.jp.nr-data.net/aws/lambda/v1"
 	LogEndpointEU   string = "https://log-api.eu.newrelic.com/log/v1"
 	LogEndpointUS   string = "https://log-api.newrelic.com/log/v1"
+	LogEndpointJP   string = "https://log-api.jp.newrelic.com/log/v1"
 
 	// WIP (configuration options?)
 	SendTimeoutRetryBase  time.Duration = 200 * time.Millisecond
@@ -90,6 +92,10 @@ func getInfraEndpointURL(licenseKey string, telemetryEndpointOverride string) st
 		return InfraEndpointEU
 	}
 
+	if strings.HasPrefix(licenseKey, "jp") {
+		return InfraEndpointJP
+	}
+
 	return InfraEndpointUS
 }
 
@@ -101,6 +107,10 @@ func getLogEndpointURL(licenseKey string, logEndpointOverride string) string {
 
 	if strings.HasPrefix(licenseKey, "eu") {
 		return LogEndpointEU
+	}
+
+	if strings.HasPrefix(licenseKey, "jp") {
+		return LogEndpointJP
 	}
 
 	return LogEndpointUS

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -458,12 +458,14 @@ func TestGetInfraEndpointURL(t *testing.T) {
 	assert.Equal(t, "barbaz", getInfraEndpointURL("foobar", "barbaz"))
 	assert.Equal(t, InfraEndpointUS, getInfraEndpointURL("us license key", ""))
 	assert.Equal(t, InfraEndpointEU, getInfraEndpointURL("eu license key", ""))
+	assert.Equal(t, InfraEndpointJP, getInfraEndpointURL("jp license key", ""))
 }
 
 func TestGetLogEndpointURL(t *testing.T) {
 	assert.Equal(t, "barbaz", getLogEndpointURL("foobar", "barbaz"))
 	assert.Equal(t, LogEndpointUS, getLogEndpointURL("us mock license key", ""))
 	assert.Equal(t, LogEndpointEU, getLogEndpointURL("eu mock license key", ""))
+	assert.Equal(t, LogEndpointJP, getLogEndpointURL("jp mock license key", ""))
 }
 
 func TestGetNewRelicTags(t *testing.T) {


### PR DESCRIPTION
 **Summary**                                                                                                                                                                                                     
   
  - Added Japan (jp) region endpoint routing for telemetry, log, and metric APIs                                                                                                                                 
  - License keys prefixed with `jp` are now routed to JP-specific New Relic ingest endpoints
 ## Changes                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  | File | Change |
  |------|--------|
  | `telemetry/client.go` | Added `InfraEndpointJP`, `LogEndpointJP` constants and JP routing in `getInfraEndpointURL()` / `getLogEndpointURL()` |
  | `apm/metric_api.go` | Added `MetricEndpointJP` constant and JP routing in `getMetricEndpointURL()` |                                                                                                         
  | `apm/collector_test.go` | Added `TestPreconnectHost_RegionLicenseJP` test |                                                                                                                                  
  | `apm/metric_api_test.go` | Added JP license key test case |                                                                                                                                                  
  | `telemetry/client_test.go` | Added JP assertions for infra and log endpoint tests |         

**How it works**                                                                                                                                                                                                
                  
  The extension detects the region from the license key prefix (same pattern as EU):                                                                                                                             
  - `eu*` → EU endpoints
  - `jp*` → JP endpoints                                                                                                                                                                                         
  - anything else → US endpoints (default)                                                                                                                 


<img width="871" height="550" alt="Screenshot 2026-05-07 at 12 36 27 PM" src="https://github.com/user-attachments/assets/27e5f4bf-c287-4acf-95c5-b226b9de181c" />
